### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An npm library for Control Systems web applications
 
 ## Installation
 Install via npm:
-    `npm install @DiamondLightSource/cs-web-lib`
+    `npm install @diamondlightsource/cs-web-lib`
     
 ## Development
 To develop on the library code first clone this repo, install the npm package dependencies and then make changes:
@@ -34,7 +34,7 @@ A GitHub workflow has been setup to automatically publish a new package version 
 This will trigger a job on GitHub to publish a new version of the cs-web-lib to NPM. Check that this job passes.
 
 ### Publishing to NPM locally
-To publish a new version of the @DiamondLightSource/cs-web-lib package you must first have an npm account and be a member of the DiamondLightSource organisation. Then:
+To publish a new version of the @diamondlightsource/cs-web-lib package you must first have an npm account and be a member of the DiamondLightSource organisation. Then:
 1. Update the package version in package.json (follow the major.minor.patch versioning terminology).
 2. Run the rollup command to package the library: `npm run rollup`.
 3. Login to your npm account: `npm adduser`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An npm library for Control Systems web applications
 
 ## Installation
 Install via npm:
-    `npm install @dls-controls/cs-web-lib`
+    `npm install @DiamondLightSource/cs-web-lib`
     
 ## Development
 To develop on the library code first clone this repo, install the npm package dependencies and then make changes:
@@ -34,7 +34,7 @@ A GitHub workflow has been setup to automatically publish a new package version 
 This will trigger a job on GitHub to publish a new version of the cs-web-lib to NPM. Check that this job passes.
 
 ### Publishing to NPM locally
-To publish a new version of the @dls-controls/cs-web-lib package you must first have an npm account and be a member of the dls-controls organisation. Then:
+To publish a new version of the @DiamondLightSource/cs-web-lib package you must first have an npm account and be a member of the DiamondLightSource organisation. Then:
 1. Update the package version in package.json (follow the major.minor.patch versioning terminology).
 2. Run the rollup command to package the library: `npm run rollup`.
 3. Login to your npm account: `npm adduser`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@DiamondLightSource/cs-web-lib",
+  "name": "@diamondlightsource/cs-web-lib",
   "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@DiamondLightSource/cs-web-lib",
+      "name": "@diamondlightsource/cs-web-lib",
       "version": "0.2.3",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@dls-controls/cs-web-lib",
+  "name": "@DiamondLightSource/cs-web-lib",
   "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dls-controls/cs-web-lib",
+      "name": "@DiamondLightSource/cs-web-lib",
       "version": "0.2.3",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dls-controls/cs-web-lib",
+  "name": "@DiamondLightSource/cs-web-lib",
   "version": "0.2.3",
   "description": "Constrol system web library",
   "main": "dist/cjs/index.js",
@@ -15,7 +15,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dls-controls/cs-web-lib.git"
+    "url": "https://github.com/DiamondLightSource/cs-web-lib.git"
   },
   "dependencies": {
     "apollo-link-retry": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@DiamondLightSource/cs-web-lib",
+  "name": "@diamondlightsource/cs-web-lib",
   "version": "0.2.3",
   "description": "Constrol system web library",
   "main": "dist/cjs/index.js",

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -1,5 +1,5 @@
 /* Module that handles a GraphQL connection to the Coniql server.
-   See https://github.com/dls-controls/coniql
+   See https://github.com/DiamondLightSource/coniql
  */
 import log from "loglevel";
 import base64js from "base64-js";


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/cs-web-lib` using https://gitlab.diamond.ac.uk/github/github-scripts