### PR TITLE
Update symbol widget

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -51,7 +51,8 @@ const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   progressbar: "progressbar",
   rectangle: "shape",
   choice: "choicebutton",
-  scaledslider: "slidecontrol"
+  scaledslider: "slidecontrol",
+  symbol: "symbol"
 };
 
 // Default width and height of widgets in Phoebus
@@ -75,7 +76,8 @@ export const WIDGET_DEFAULT_SIZES: { [key: string]: [number, number] } = {
   polyline: [100, 20],
   progressbar: [100, 20],
   rectangle: [100, 20],
-  scaledslider: [400, 55]
+  scaledslider: [400, 55],
+  symbol: [100, 100]
 };
 
 function bobParseType(props: any): string {
@@ -206,6 +208,14 @@ function bobParseResizing(jsonProp: ElementCompact): string {
   }
 }
 
+function bobParseSymbols(jsonProp: ElementCompact): string[] {
+  const symbols: string[] = [];
+  jsonProp["symbol"].forEach((item: any) => {
+    symbols.push(item._text);
+  });
+  return symbols;
+}
+
 function bobGetTargetWidget(props: any): React.FC {
   const typeid = bobParseType(props);
   let targetWidget;
@@ -257,7 +267,11 @@ export function parseBob(
     squareLed: ["square", opiParseBoolean],
     formatType: ["format", bobParseFormatType],
     stretchToFit: ["stretch_image", opiParseBoolean],
-    macros: ["macros", opiParseMacros]
+    macros: ["macros", opiParseMacros],
+    symbols: ["symbols", bobParseSymbols],
+    initialIndex: ["initial_index", bobParseNumber],
+    showIndex: ["show_index", opiParseBoolean],
+    fallbackSymbol: ["fallback_symbol", opiParseString]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -271,7 +271,8 @@ export function parseBob(
     symbols: ["symbols", bobParseSymbols],
     initialIndex: ["initial_index", bobParseNumber],
     showIndex: ["show_index", opiParseBoolean],
-    fallbackSymbol: ["fallback_symbol", opiParseString]
+    fallbackSymbol: ["fallback_symbol", opiParseString],
+    rotation: ["rotation", bobParseNumber]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -211,7 +211,9 @@ function bobParseResizing(jsonProp: ElementCompact): string {
 function bobParseSymbols(jsonProp: ElementCompact): string[] {
   const symbols: string[] = [];
   Object.values(jsonProp["symbol"]).forEach((item: any) => {
-    symbols.push(item);
+    // For a single symbol, we are passed a string. For multiple symbols
+    // we are passed an object, so we need to return string from it
+    symbols.push(typeof item === "string" ? item : item._text);
   });
   return symbols;
 }

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -210,8 +210,8 @@ function bobParseResizing(jsonProp: ElementCompact): string {
 
 function bobParseSymbols(jsonProp: ElementCompact): string[] {
   const symbols: string[] = [];
-  jsonProp["symbol"].forEach((item: any) => {
-    symbols.push(item._text);
+  Object.values(jsonProp["symbol"]).forEach((item: any) => {
+    symbols.push(item);
   });
   return symbols;
 }

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -23,7 +23,8 @@ const ImageProps = {
   rotation: FloatPropOpt,
   flipHorizontal: BoolPropOpt,
   flipVertical: BoolPropOpt,
-  onClick: FuncPropOpt
+  onClick: FuncPropOpt,
+  overflow: BoolPropOpt
 };
 
 export const ImageComponent = (
@@ -39,7 +40,7 @@ export const ImageComponent = (
 
   let imageHeight: string | undefined = undefined;
   let imageWidth: string | undefined = undefined;
-  const overflow = "hidden";
+  const overflow = props.overflow ? "visible" : "hidden";
   if (props.stretchToFit) {
     imageWidth = "100%";
     imageHeight = "100%";

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<Symbol /> from .bob file use initialIndex if no props value provided 1
     style="justify-content: center; align-content: center;"
   >
     <span
-      style="height: 30px; width: 30px; border-radius: 50%; background-color: black; border: 1px solid white; color: white; position: absolute; top: calc(50% - 15px); left: calc(50% - 15px); text-align: center;"
+      class="IndexLabel"
     >
       <b>
         2
@@ -61,7 +61,8 @@ exports[`<Symbol /> from .opi file matches snapshot 1`] = `
     />
   </div>
   <div
-    style="background-color: transparent; position: absolute; height: 100%; width: 100%; top: 0px; left: 0px; display: flex; align-items: center; justify-content: center;"
+    class="SymbolLabel"
+    style="background-color: transparent; align-items: center; justify-content: center;"
   >
     <div
       style="padding: 5%;"

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
@@ -16,11 +16,24 @@ exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`
 exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 3.svg"
       style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file > matches snapshot (with rotation) 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 1.gif"
+      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill;"
     />
   </div>
 </DocumentFragment>
@@ -29,7 +42,7 @@ exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
 exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
@@ -39,40 +52,14 @@ exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
 </DocumentFragment>
 `;
 
-exports[`<Symbol /> from .bob file matches snapshot (using fallback symbol) 1`] = `
+exports[`<Symbol /> from .opi file > matches snapshot (with rotation) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
-  >
-    <img
-      src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`<Symbol /> from .bob file matches snapshot (with index) 1`] = `
-<DocumentFragment>
-  <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
-  >
-    <img
-      src="img 3.svg"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`<Symbol /> from .bob file matches snapshot (without index) 1`] = `
-<DocumentFragment>
-  <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill;"
     />
   </div>
 </DocumentFragment>
@@ -81,7 +68,7 @@ exports[`<Symbol /> from .bob file matches snapshot (without index) 1`] = `
 exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
@@ -90,36 +77,6 @@ exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
   </div>
   <div
     class="_SymbolLabel_7b7af1"
-    style="background-color: transparent; align-items: center; justify-content: center;"
-  >
-    <div
-      style="padding: 5%;"
-    >
-      <div
-        class="Label _Label_c35983"
-        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start;"
-      >
-        <span>
-           Fake value 
-        </span>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`<Symbol /> from .opi file matches snapshot 1`] = `
-<DocumentFragment>
-  <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
-  >
-    <img
-      src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
-    />
-  </div>
-  <div
-    class="SymbolLabel"
     style="background-color: transparent; align-items: center; justify-content: center;"
   >
     <div

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -1,19 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<Symbol /> from .bob file use arrayIndex to find index if value is an array 1`] = `
-<DocumentFragment>
-  <div
-    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
-  >
-    <img
-      src="img 3.svg"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`<Symbol /> from .bob file use fallbackSymbol if index out of range or no symbol provided 1`] = `
+exports[`<Symbol /> from .bob file matches snapshot (using fallback symbol) 1`] = `
 <DocumentFragment>
   <div
     style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
@@ -26,7 +13,7 @@ exports[`<Symbol /> from .bob file use fallbackSymbol if index out of range or n
 </DocumentFragment>
 `;
 
-exports[`<Symbol /> from .bob file use initialIndex if no props value provided 1`] = `
+exports[`<Symbol /> from .bob file matches snapshot (with index) 1`] = `
 <DocumentFragment>
   <div
     style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
@@ -36,16 +23,18 @@ exports[`<Symbol /> from .bob file use initialIndex if no props value provided 1
       style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
     />
   </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file matches snapshot (without index) 1`] = `
+<DocumentFragment>
   <div
-    style="justify-content: center; align-content: center;"
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
   >
-    <span
-      class="IndexLabel"
-    >
-      <b>
-        2
-      </b>
-    </span>
+    <img
+      src="img 1.gif"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -1,13 +1,63 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<Symbol /> > matches snapshot 1`] = `
+exports[`<Symbol /> from .bob file use arrayIndex to find index if value is an array 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: hidden; text-align: left;"
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 3.svg"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file use fallbackSymbol if index out of range or no symbol provided 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file use initialIndex if no props value provided 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 3.svg"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+  <div
+    style="justify-content: center; align-content: center;"
+  >
+    <span
+      style="height: 30px; width: 30px; border-radius: 50%; background-color: black; border: 1px solid white; color: white; position: absolute; top: calc(50% - 15px); left: calc(50% - 15px); text-align: center;"
+    >
+      <b>
+        2
+      </b>
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .opi file matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
-      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: none;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
     />
   </div>
   <div

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -1,5 +1,44 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 3.svg"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 1.gif"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<Symbol /> from .bob file matches snapshot (using fallback symbol) 1`] = `
 <DocumentFragment>
   <div
@@ -35,6 +74,36 @@ exports[`<Symbol /> from .bob file matches snapshot (without index) 1`] = `
       src="img 1.gif"
       style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
     />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    style="overflow: hidden; text-align: left; width: 100%; height: 100%;"
+  >
+    <img
+      src="img 1.gif"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+    />
+  </div>
+  <div
+    class="_SymbolLabel_7b7af1"
+    style="background-color: transparent; align-items: center; justify-content: center;"
+  >
+    <div
+      style="padding: 5%;"
+    >
+      <div
+        class="Label _Label_c35983"
+        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start;"
+      >
+        <span>
+           Fake value 
+        </span>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/ui/widgets/Symbol/symbol.module.css
+++ b/src/ui/widgets/Symbol/symbol.module.css
@@ -1,0 +1,23 @@
+.IndexLabel {
+    height: 30px;
+    width: 30px;
+    border-radius: 50%;
+    background-color: black;
+    border: 1px solid white;
+    opacity: 50%;
+    color: white;
+    position: absolute;
+    top: calc(50% - 15px);
+    left: calc(50% - 15px);
+    text-align: center;
+    font-size: math;
+}
+
+.SymbolLabel {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    display: flex;
+}

--- a/src/ui/widgets/Symbol/symbol.test.tsx
+++ b/src/ui/widgets/Symbol/symbol.test.tsx
@@ -4,8 +4,10 @@ import { SymbolComponent } from "./symbol";
 import { DType } from "../../../types/dtypes";
 
 const fakeValue = new DType({ stringValue: "Fake value" });
+const stringValue = new DType({ stringValue: "1.54" })
+const arrayValue = new DType({ arrayValue: Float64Array.from([2, 0]) })
 
-describe("<Symbol />", (): void => {
+describe("<Symbol /> from .opi file", (): void => {
   test("label is not shown if showLabel is false", (): void => {
     const symbolProps = {
       showBooleanLabel: false,
@@ -40,4 +42,67 @@ describe("<Symbol />", (): void => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+});
+
+
+describe("<Symbol /> from .bob file", (): void => {
+  test("index is not shown if showIndex is false", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif"],
+      value: new DType({ stringValue: "0" })
+    };
+
+    render(<SymbolComponent {...(symbolProps as any)} />);
+
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  test("index is added", (): void => {
+    const symbolProps = {
+      showIndex: true,
+      symbols: ["img 1.gif", "img 2.png"],
+      value: stringValue
+    };
+    render(<SymbolComponent {...(symbolProps as any)} />);
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  test("use initialIndex if no props value provided", (): void => {
+    const symbolProps = {
+      showIndex: true,
+      initialIndex: 2,
+      symbols: ["img 1.gif", "img 2.png", "img 3.svg"],
+      value: undefined
+    };
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+  test("use fallbackSymbol if index out of range or no symbol provided", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif"],
+      value: new DType({ doubleValue: 1 })
+    };
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+  test("use arrayIndex to find index if value is an array", (): void => {
+    const symbolProps = {
+      arrayIndex: 0,
+      symbols: ["img 1.gif", "img 2.png", "img 3.svg"],
+      value: arrayValue
+    };
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
 });

--- a/src/ui/widgets/Symbol/symbol.test.tsx
+++ b/src/ui/widgets/Symbol/symbol.test.tsx
@@ -4,8 +4,8 @@ import { SymbolComponent } from "./symbol";
 import { DType } from "../../../types/dtypes";
 
 const fakeValue = new DType({ stringValue: "Fake value" });
-const stringValue = new DType({ stringValue: "1.54" })
-const arrayValue = new DType({ arrayValue: Float64Array.from([2, 0]) })
+const stringValue = new DType({ stringValue: "1.54" });
+const arrayValue = new DType({ arrayValue: Float64Array.from([2, 0]) });
 
 describe("<Symbol /> from .opi file", (): void => {
   test("label is not shown if showLabel is false", (): void => {
@@ -43,7 +43,6 @@ describe("<Symbol /> from .opi file", (): void => {
     expect(asFragment()).toMatchSnapshot();
   });
 });
-
 
 describe("<Symbol /> from .bob file", (): void => {
   test("index is not shown if showIndex is false", (): void => {
@@ -104,5 +103,4 @@ describe("<Symbol /> from .bob file", (): void => {
 
     expect(asFragment()).toMatchSnapshot();
   });
-
 });

--- a/src/ui/widgets/Symbol/symbol.test.tsx
+++ b/src/ui/widgets/Symbol/symbol.test.tsx
@@ -74,28 +74,54 @@ describe("<Symbol /> from .bob file", (): void => {
       symbols: ["img 1.gif", "img 2.png", "img 3.svg"],
       value: undefined
     };
-    const { asFragment } = render(
-      <SymbolComponent {...(symbolProps as any)} />
-    );
 
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test("use fallbackSymbol if index out of range or no symbol provided", (): void => {
-    const symbolProps = {
-      symbols: ["img 1.gif"],
-      value: new DType({ doubleValue: 1 })
-    };
-    const { asFragment } = render(
-      <SymbolComponent {...(symbolProps as any)} />
-    );
+    render(<SymbolComponent {...(symbolProps as any)} />);
 
-    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByText("2")).toBeInTheDocument();
   });
+
   test("use arrayIndex to find index if value is an array", (): void => {
     const symbolProps = {
       arrayIndex: 0,
+      showIndex: true,
       symbols: ["img 1.gif", "img 2.png", "img 3.svg"],
       value: arrayValue
+    };
+    render(<SymbolComponent {...(symbolProps as any)} />);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  test("matches snapshot (without index)", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif"],
+      value: new DType({ stringValue: "0" })
+    };
+
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test("matches snapshot (with index)", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif", "img 2.png", "img 3.svg"],
+      value: new DType({ stringValue: "2" })
+    };
+
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test("matches snapshot (using fallback symbol)", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif"],
+      value: new DType({ doubleValue: 1 })
     };
     const { asFragment } = render(
       <SymbolComponent {...(symbolProps as any)} />

--- a/src/ui/widgets/Symbol/symbol.test.tsx
+++ b/src/ui/widgets/Symbol/symbol.test.tsx
@@ -42,6 +42,21 @@ describe("<Symbol /> from .opi file", (): void => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test("matches snapshot (with rotation)", (): void => {
+    const symbolProps = {
+      showBooleanLabel: false,
+      imageFile: "img 1.gif",
+      value: fakeValue,
+      rotation: 45
+    };
+
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });
 
 describe("<Symbol /> from .bob file", (): void => {
@@ -123,6 +138,20 @@ describe("<Symbol /> from .bob file", (): void => {
       symbols: ["img 1.gif"],
       value: new DType({ doubleValue: 1 })
     };
+    const { asFragment } = render(
+      <SymbolComponent {...(symbolProps as any)} />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test("matches snapshot (with rotation)", (): void => {
+    const symbolProps = {
+      symbols: ["img 1.gif"],
+      value: new DType({ stringValue: "0" }),
+      rotation: 45
+    };
+
     const { asFragment } = render(
       <SymbolComponent {...(symbolProps as any)} />
     );

--- a/src/ui/widgets/Symbol/symbol.tsx
+++ b/src/ui/widgets/Symbol/symbol.tsx
@@ -240,16 +240,14 @@ function convertValueToIndex(
   // If no value, use initialIndex
   if (value === undefined) return initialIndex;
   // First we check if we have a string
-  const isArray = value.getArrayValue()?.length !== undefined ? true : false
+  const isArray = value.getArrayValue()?.length !== undefined ? true : false;
   if (isArray) {
     // If is array, get index
     const arrayValue = DType.coerceArray(value);
     const idx = Number(arrayValue[arrayIndex]);
     return Math.floor(idx);
   } else {
-    console.log(value);
     const intValue = DType.coerceDouble(value);
-    console.log(intValue);
     if (!isNaN(intValue)) return Math.floor(intValue);
   }
   return initialIndex;

--- a/src/ui/widgets/Symbol/symbol.tsx
+++ b/src/ui/widgets/Symbol/symbol.tsx
@@ -22,6 +22,7 @@ import { executeActions, WidgetActions } from "../widgetActions";
 import { MacroContext } from "../../../types/macros";
 import { ExitFileContext, FileContext } from "../../../misc/fileContext";
 import { DType } from "../../../types/dtypes";
+import classes from "./symbol.module.css";
 
 const SymbolProps = {
   imageFile: StringPropOpt,
@@ -166,20 +167,15 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
       ) : showBooleanLabel ? (
         <>
           <div
+            className={classes.SymbolLabel}
             onClick={onClick}
             style={{
               ...style,
               backgroundColor: transparent
                 ? "transparent"
                 : backgroundColor.toString(),
-              position: "absolute",
-              height: "100%",
-              width: "100%",
-              top: 0,
-              left: 0,
-              display: "flex",
-              alignItems,
-              justifyContent
+              alignItems: alignItems,
+              justifyContent: justifyContent
             }}
           >
             <div style={{ padding: "5%" }}>
@@ -206,22 +202,7 @@ function generateIndexLabel(index: number, showIndex: boolean): JSX.Element {
   // Create span
   return (
     <div style={{ justifyContent: "center", alignContent: "center" }}>
-      <span
-        style={{
-          height: "30px",
-          width: "30px",
-          borderRadius: "50%",
-          backgroundColor: "black",
-          border: "1px solid white",
-          opacity: "50%",
-          color: "white",
-          position: "absolute",
-          top: "calc(50% - 15px)",
-          left: "calc(50% - 15px)",
-          textAlign: "center",
-          fontSize: "math"
-        }}
-      >
+      <span className={classes.IndexLabel}>
         <b>{index}</b>
       </span>
     </div>

--- a/src/ui/widgets/Symbol/symbol.tsx
+++ b/src/ui/widgets/Symbol/symbol.tsx
@@ -93,13 +93,6 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
     imageFile = imageFile.replace(regex, ` ${intValue.toFixed(0)}.`);
   }
 
-  // Symbol in Phoebus has no label but can display index
-  const labelText = isBob
-    ? showIndex
-      ? index.toString()
-      : ""
-    : props.value?.getStringValue();
-
   let alignItems = "center";
   let justifyContent = "center";
   switch (props.labelPosition) {
@@ -182,7 +175,7 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
               <LabelComponent
                 {...props}
                 backgroundColor={Color.TRANSPARENT}
-                text={labelText}
+                text={props.value?.getStringValue()}
               ></LabelComponent>
             </div>
           </div>

--- a/src/ui/widgets/Symbol/symbol.tsx
+++ b/src/ui/widgets/Symbol/symbol.tsx
@@ -154,6 +154,7 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
         imageFile={imageFile}
         onClick={onClick}
         stretchToFit={true}
+        overflow={true}
       />
       {isBob ? (
         labelDiv


### PR DESCRIPTION
Current implementation of the Symbol widget in cs-web-lib was based off the MultiStateMonitor widget in CSStudio. The Phoebus Symbol widget implementation was not applied.

I've now updated this widget to behave like the Phoebus widget. Tests and snapshots have also been updated. We check whether the symbol should behave like MultiStateMonitor or Symbol, so both opi and bob file behaviours are preserved. 