### PR TITLE
Change rollup input path

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
     ],
   },
   {
-    input: "dist/esm/types/index.d.ts",
+    input: "dist/esm/index.d.ts",
     output: [{ file: "dist/index.d.ts", format: "esm" }],
     plugins: [dts()],
 


### PR DESCRIPTION
For rollout versions > 8.3.3, the `declarationDir` property in tsconfig.json is ignored as mentioned here https://github.com/rollup/plugins/issues/1230. With the recent vite changes a new version of rollout 8.5.0 was pulled into the project.

This changes the location of where in the `dist` directory files are located, and so I have updated the input path corresponding to this new location. The package still works without this change when imported in another project, but will fail when running `tsc` and shows an error in vscode:

```
src/index.tsx:7:10 - error TS2305: Module '"@diamondlightsource/cs-web-lib"' has no exported member 'FileProvider'.

7 import { FileProvider, OutlineProvider } from "@diamondlightsource/cs-web-lib";
```