### PR TITLE
Fix vite issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.3.0",
   "description": "Control system web library",
   "main": "dist/cjs/index.js",
-  "type": "module",
   "scripts": {
     "rollup": "rollup -c",
     "test": "vitest",

--- a/src/misc/profilerCallback.ts
+++ b/src/misc/profilerCallback.ts
@@ -8,7 +8,9 @@ import log from "loglevel";
  * and for more reliable measurements
  */
 
-const PROFILE_ENABLED = import.meta.env.VITE_PROFILER_ENABLED === "true";
+const PROFILE_ENABLED =
+  (process.env.VITE_PROFILER_ENABLED ??
+    import.meta.env.VITE_PROFILER_ENABLED) === "true";
 const ITEMS_TO_STORE = 100;
 
 class Timings {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -8,10 +8,14 @@ import { SimulatorPlugin } from "../connection/sim";
 import { ConiqlPlugin } from "../connection/coniql";
 import { ConnectionForwarder } from "../connection/forwarder";
 
-const CONIQL_SOCKET = import.meta.env.VITE_CONIQL_SOCKET;
-const CONIQL_SSL = import.meta.env.VITE_CONIQL_SSL === "true";
+const CONIQL_SOCKET =
+  process.env.VITE_CONIQL_SOCKET ?? import.meta.env.VITE_CONIQL_SOCKET;
+const CONIQL_SSL =
+  (process.env.VITE_CONIQL_SSL ?? import.meta.env.VITE_CONIQL_SSL) === "true";
 const THROTTLE_PERIOD = parseFloat(
-  import.meta.env.VITE_THROTTLE_PERIOD ?? "100"
+  process.env.VITE_THROTTLE_PERIOD ??
+    import.meta.env.VITE_THROTTLE_PERIOD ??
+    "100"
 );
 
 const simulator = new SimulatorPlugin();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,10 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": [
+      "vite/client"
+    ],
   },
   "include": [
     "src"


### PR DESCRIPTION
After migrating to use vite the other day, I noticed a few issues when utilising cs-web-lib in machine-status:

- Previously added `"type": "module"` into package.json. This has now been removed because it isn't needed and causes an error when running tests in machine-status:
```
ReferenceError: exports is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/node_modules/@diamondlightsource/cs-web-lib/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```
-  Vite exposes environment variables on `import.meta.env` instead of `process.env` so I had previously changed this over, but in order to maintain compatibility and allow client applications still using cra to use cs-web-lib, I've modified it so that both are used. We attempt to use `process.env` first and if that is empty, fall back to `import.meta.env`

The changes in the PR should correct these issues.