### PR TITLE
Fix state update on an unmounted component

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/useOpiFile.ts
+++ b/src/ui/widgets/EmbeddedDisplay/useOpiFile.ts
@@ -78,14 +78,14 @@ export function useOpiFile(file: File): WidgetDescription {
   const [contents, setContents] = useState<WidgetDescription>(EMPTY_WIDGET);
 
   useEffect(() => {
-    let isMounted = false;
+    let isMounted = true;
     const fetchData = async (): Promise<void> => {
       if (fetchPromises.hasOwnProperty(file.path)) {
         // This resource has been requested; once the cached
         // promise has been resolved the fileCache should be
         // populated.
         await fetchPromises[file.path];
-        if (!isMounted) {
+        if (isMounted) {
           setContents(fileCache[file.path]);
         }
       } else {
@@ -95,7 +95,7 @@ export function useOpiFile(file: File): WidgetDescription {
         const contents = await fetchPromise;
         // Populate the file cache.
         fileCache[file.path] = contents;
-        if (!isMounted) {
+        if (isMounted) {
           setContents(contents);
         }
       }
@@ -104,7 +104,7 @@ export function useOpiFile(file: File): WidgetDescription {
 
     // Tidy up in case component is unmounted
     return () => {
-      isMounted = true;
+      isMounted = false;
     };
   }, [file.path, file.defaultProtocol, fileExt]);
 

--- a/src/ui/widgets/EmbeddedDisplay/useOpiFile.ts
+++ b/src/ui/widgets/EmbeddedDisplay/useOpiFile.ts
@@ -77,14 +77,17 @@ export function useOpiFile(file: File): WidgetDescription {
   const fileExt = file.path.split(".").pop() || "json";
   const [contents, setContents] = useState<WidgetDescription>(EMPTY_WIDGET);
 
-  useEffect((): void => {
+  useEffect(() => {
+    let isMounted = false;
     const fetchData = async (): Promise<void> => {
       if (fetchPromises.hasOwnProperty(file.path)) {
         // This resource has been requested; once the cached
         // promise has been resolved the fileCache should be
         // populated.
         await fetchPromises[file.path];
-        setContents(fileCache[file.path]);
+        if (!isMounted) {
+          setContents(fileCache[file.path]);
+        }
       } else {
         const fetchPromise = fetchAndConvert(file.path, file.defaultProtocol);
         // Populate the promises cache.
@@ -92,10 +95,17 @@ export function useOpiFile(file: File): WidgetDescription {
         const contents = await fetchPromise;
         // Populate the file cache.
         fileCache[file.path] = contents;
-        setContents(contents);
+        if (!isMounted) {
+          setContents(contents);
+        }
       }
     };
     fetchData();
+
+    // Tidy up in case component is unmounted
+    return () => {
+      isMounted = true;
+    };
   }, [file.path, file.defaultProtocol, fileExt]);
 
   return contents;


### PR DESCRIPTION
After updating the machine-status client to use `vite` and `vitest` I noticed that I was getting some warnings when running the tests:
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at EmbeddedDisplay (/home/user/cs-web/machine-status/node_modules/@diamondlightsource/cs-web-lib/dist/cjs/index.js:54548:42)
    at LoadEmbeddedDirect (/home/user/cs-web/machine-status/src/app.tsx:39:29)
    at RedirectAfterTimeout (/home/user/cs-web/machine-status/src/app.tsx:618:1)
    at LoadRedirectView
    at Route (/home/user/cs-web/machine-status/node_modules/react-router/cjs/react-router.js:664:29)
    at Switch (/home/user/cs-web/machine-status/node_modules/react-router/cjs/react-router.js:866:29)
    at div
    at Provider (/home/user/cs-web/machine-status/node_modules/react-redux/lib/components/Provider.js:21:20)
    at AppScreen (/home/user/cs-web/machine-status/src/app.tsx:105:22)
    at Router (/home/user/cs-web/machine-status/node_modules/react-router/cjs/react-router.js:283:30)
    at BrowserRouter (/home/user/cs-web/machine-status/node_modules/react-router-dom/cjs/react-router-dom.js:75:35)
```
As it states, it is due to it trying to update the state on an unmounted component. This might not be an issue in production but is highlighted in the tests as the component gets unmounted almost immediately after mounting.

To eliminate this I have simply added a check that the component is mounted before updating the state and then have added a return function which is called when the component is unmounted and can set the `isMounted` check variable to `false`.