### PR TITLE
Export some hooks and necessary datatypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -1,0 +1,1 @@
+export * from "./plugin";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export * from "./redux";
 export * from "./misc";
+export * from "./connection";
 export * from "./ui/components";
 export * from "./ui/widgets";
+export * from "./ui/hooks";
 export * from "./types";
 export { contextRender } from "./testResources";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export { Color } from "./color";
 export { PV } from "./pv";
 export { Font, FontStyle } from "./font";
 export { Border, BorderStyle } from "./border";
+export { DType } from "./dtypes";

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useDevice } from "./useDevice";
+export { useConnection } from "./useConnection";


### PR DESCRIPTION
Fixes #68 

I think this is enough to get us going, thanks for being open to these changes!

We might want to add a few more later but I'm erring on the side of caution for the moment. We are actually kind of interested in splitting out the PVWS communication + React hooks into a separate library (which we would be willing to help maintain!) because it could be reused in a lot of projects which don't correspond to CS-Studio stuff, but that is a discussion to have with @DominicOram next year.