### PR TITLE
Preserve 'use-client' directives during rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
+        "rollup-preserve-directives": "^1.1.3",
         "typescript": "^5.6.3",
         "vite": "^5.4.10",
         "vite-plugin-eslint": "^1.8.1",
@@ -12675,6 +12676,19 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
+    },
+    "node_modules/rollup-preserve-directives": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-preserve-directives/-/rollup-preserve-directives-1.1.3.tgz",
+      "integrity": "sha512-oXqxd6ZzkoQej8Qt0k+S/yvO2+S4CEVEVv2g85oL15o0cjAKTKEuo2MzyA8FcsBBXbtytBzBMFAbhvQg4YyPUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
+    "rollup-preserve-directives": "^1.1.3",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vite-plugin-eslint": "^1.8.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,6 +5,7 @@ import dts from "rollup-plugin-dts";
 
 import postcss from "rollup-plugin-postcss";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
+import preserveDirectives from 'rollup-preserve-directives'
 
 const config = [
   {
@@ -29,7 +30,8 @@ const config = [
         tsconfig: "./tsconfig.json",
         compilerOptions: { outDir: "dist" }
       }),
-      postcss()
+      postcss(),
+      preserveDirectives()
     ]
   },
   {


### PR DESCRIPTION
Previously we were getting a lot of warnings thrown during `rollup` that the `use client` directive from the 'mui' package were ignored:
```
(!) node_modules/@mui/styled-engine/GlobalStyles/GlobalStyles.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/@mui/styled-engine/GlobalStyles/GlobalStyles.js" was ignored.
/cs-web-lib/node_modules/@mui/styled-engine/GlobalStyles/GlobalStyles.js:1:0
1: 'use client';
   ^
2: 
3: import * as React from 'react';
```

This `use client` directive is used by the mui package to mark the module as client code and therefore should probably be preserved during the rollup. There is a package `rollup-preserve-directives` that can do this so I have added this and configured it in the rollup.config file.