### PR TITLE
Fix findDOMNode deprecation warning in slideshow widget

### DIFF
--- a/src/ui/widgets/Slideshow/slideshow.tsx
+++ b/src/ui/widgets/Slideshow/slideshow.tsx
@@ -31,10 +31,15 @@ export const SwitchableWidget = (props: {
   index: number;
   children: [ReactElement];
   transition: { readonly [key: string]: string };
+  nodeRef: React.Ref<HTMLDivElement>;
 }): JSX.Element => {
+  // react-transition-group internally uses findDOMNode which
+  // is deprecated. Fix by passing nodeRef which points to the
+  // transitioning child.
   return (
     <SwitchTransition mode="out-in">
       <CSSTransition
+        nodeRef={props.nodeRef}
         classNames={props.transition}
         key={props.index}
         timeout={250}
@@ -69,6 +74,7 @@ export const SlideshowComponent = (
   const [transition, setTransition] = useState(slideRightTransition);
 
   log.debug(`Slideshow Index: ${childIndex}`);
+  const nodeRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <div
@@ -104,6 +110,7 @@ export const SlideshowComponent = (
         ◀
       </button>
       <div
+        ref={nodeRef}
         style={{
           position: "relative",
           width: "80%",
@@ -114,7 +121,11 @@ export const SlideshowComponent = (
           overflow: props.overflow ?? ""
         }}
       >
-        <SwitchableWidget index={childIndex} transition={transition}>
+        <SwitchableWidget
+          index={childIndex}
+          transition={transition}
+          nodeRef={nodeRef}
+        >
           {props.children as [ReactElement]}
         </SwitchableWidget>
       </div>


### PR DESCRIPTION
This warning is currently thrown when running the tests:
```
Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node
    at Transition (/cs-web-lib/node_modules/react-transition-group/cjs/Transition.js:135:30)
    at CSSTransition (/cs-web-lib/node_modules/react-transition-group/cjs/CSSTransition.js:120:35)
    at SwitchTransition (/cs-web-lib/node_modules/react-transition-group/cjs/SwitchTransition.js:159:35)
    at SwitchableWidget (/cs-web-lib/src/ui/widgets/Slideshow/slideshow.tsx:49:25)
    at div
    at div
    at SlideshowComponent (/cs-web-lib/src/ui/widgets/Slideshow/slideshow.tsx:86:61)
```

I've followed the advice to pass a `ref` directly into the element and `CSSTransition` component. Also see discussion here with a similar suggestion/implementation: https://github.com/reactjs/react-transition-group/issues/668.

Beyond this, I'm actually not sure where the slideshow widget is used? Maybe it can actually be removed...