### PR TITLE
Update profiler callback properties for react 18

### DIFF
--- a/src/misc/profilerCallback.ts
+++ b/src/misc/profilerCallback.ts
@@ -64,12 +64,11 @@ const timings = new Timings();
  */
 export function onRenderCallback(
   id: string,
-  phase: "mount" | "update",
+  phase: "mount" | "update" | "nested-update",
   actualDuration: number,
   baseDuration: number,
   startTime: number,
-  commitTime: number,
-  interactions: unknown
+  commitTime: number
 ): void {
   if (PROFILE_ENABLED) {
     const reconciliationTime = commitTime - startTime;


### PR DESCRIPTION
With React 18, it seems some of the properties of the onRender callback have changed:

- `phase` variable can now also be "nested-update", as well as "mount" and "update"
- `interactions` variable has been removed

Without these changes, tsc fails in machine status and other clients with this error:
```
src/app.tsx:107:46 - error TS2322: Type '(id: string, phase: "mount" | "update", actualDuration: number, baseDuration: number, startTime: number, commitTime: number, interactions: unknown) => void' is not assignable to type 'ProfilerOnRenderCallback'.

107         <Profiler id="Dynamic Page Profiler" onRender={onRenderCallback}>

src/app.tsx:107:46 - error TS2322: Type '(id: string, phase: "mount" | "update", actualDuration: number, baseDuration: number, startTime: number, commitTime: number) => void' is not assignable to type 'ProfilerOnRenderCallback'.
  Types of parameters 'phase' and 'phase' are incompatible.
    Type '"mount" | "update" | "nested-update"' is not assignable to type '"mount" | "update"'.
      Type '"nested-update"' is not assignable to type '"mount" | "update"'.

107         <Profiler id="Dynamic Page Profiler" onRender={onRenderCallback}>

```