### PR TITLE
Add the key prop to the 'Error' component

### DIFF
--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -67,7 +67,8 @@ export function widgetDescriptionToComponent(
     log.warn(message);
     log.warn(widgetDescription);
     return widgetDescriptionToComponent(
-      errorWidget(message, widgetDescription["position"])
+      errorWidget(message, widgetDescription["position"]),
+      listIndex
     );
   }
 


### PR DESCRIPTION
We are getting warnings in the tests when a widget is undefined:
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `EmbeddedDisplay`. See https://reactjs.org/link/warning-keys for more information.
    at Label
    at EmbeddedDisplay (/home/rjaw/cs-web/cs-web-proto/node_modules/@diamondlightsource/cs-web-lib/dist/cjs/index.js:9941:42)
    at LoadEmbedded (/home/rjaw/cs-web/cs-web-proto/src/app.tsx:33:39)
    at Route (/home/rjaw/cs-web/cs-web-proto/node_modules/react-router/cjs/react-router.js:664:29)
    at Switch (/home/rjaw/cs-web/cs-web-proto/node_modules/react-router/cjs/react-router.js:866:29)
    at div
    at Provider (/home/rjaw/cs-web/cs-web-proto/node_modules/react-redux/lib/components/Provider.js:21:20)
    at App
    at Router (/home/rjaw/cs-web/cs-web-proto/node_modules/react-router/cjs/react-router.js:283:30)
    at BrowserRouter (/home/rjaw/cs-web/cs-web-proto/node_modules/react-router-dom/cjs/react-router-dom.js:75:35)
```
This is because the Error component that we create in this case is missing the `key' prop. Simple fix is to just add one which is anyway already available to us.