### PR TITLE
Add bobParseActions

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -250,9 +250,12 @@ export function bobParseActions(
       case "replace":
         return "main";
       case "tab":
-        return "details";
+        // If a named tab is given, open there
+        // Otherwise default to main
+        if (action.name) return action.name._text;
+        return "main";
       default:
-        return "details";
+        return "main";
     }
   };
 

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -23,6 +23,7 @@ import {
 import { PV } from "../../../types/pv";
 import { OpiFile, Rule } from "../../../types/props";
 import {
+  OPEN_PAGE,
   OPEN_TAB,
   OPEN_WEBPAGE,
   WidgetActions,
@@ -282,8 +283,9 @@ export function bobParseActions(
           }
         });
       } else if (type === "open_display") {
+        const type = action.target._text === "replace" ? OPEN_PAGE : OPEN_TAB;
         processedActions.actions.push({
-          type: OPEN_TAB,
+          type: type,
           dynamicInfo: {
             name: action.file._text,
             location: actionToLocation(action),

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -1,5 +1,5 @@
 import { REGISTERED_WIDGETS } from "../register";
-import { ComplexParserDict, parseWidget, ParserDict } from "./parser";
+import { ComplexParserDict, parseWidget, ParserDict, toArray } from "./parser";
 import {
   XmlDescription,
   OPI_COMPLEX_PARSERS,
@@ -7,7 +7,6 @@ import {
   OPI_PATCHERS,
   opiParseRules,
   opiParsePvName,
-  opiParseActions,
   opiParseColor,
   opiParseAlarmSensitive,
   opiParseString,
@@ -23,7 +22,12 @@ import {
 } from "../../../types/position";
 import { PV } from "../../../types/pv";
 import { OpiFile, Rule } from "../../../types/props";
-import { WidgetActions } from "../widgetActions";
+import {
+  OPEN_TAB,
+  OPEN_WEBPAGE,
+  WidgetActions,
+  WRITE_PV
+} from "../widgetActions";
 import { Font, FontStyle } from "../../../types/font";
 import { Border, BorderStyle } from "../../../types/border";
 import { Color } from "../../../types/color";
@@ -217,6 +221,92 @@ function bobParseSymbols(jsonProp: ElementCompact): string[] {
   });
   return symbols;
 }
+/**
+ * Creates a WidgetActions object from the actions tied to the json object
+ * @param jsonProp
+ * @param defaultProtocol
+ */
+export function bobParseActions(
+  jsonProp: ElementCompact,
+  defaultProtocol: string
+): WidgetActions {
+  const actionsToProcess = toArray(jsonProp.action);
+
+  // Extract information about whether to execute all actions at once
+  const executeAsOne = jsonProp._attributes?.execute_as_one === "true";
+
+  // Turn into an array of Actions
+  const processedActions: WidgetActions = {
+    executeAsOne: executeAsOne,
+    actions: []
+  };
+
+  const actionToLocation = (action: ElementCompact): string => {
+    // Bob options "replace" and "tab" correspond to opening
+    // in the main view, or in a new panel/tab
+    const target = action.target._text;
+    switch (target) {
+      case "replace":
+        return "main";
+      case "tab":
+        return "details";
+      default:
+        return "details";
+    }
+  };
+
+  actionsToProcess.forEach((action): void => {
+    log.debug(action);
+    const type = action._attributes?.type;
+    try {
+      if (type === "write_pv") {
+        processedActions.actions.push({
+          type: WRITE_PV,
+          writePvInfo: {
+            pvName: opiParsePvName(
+              action.pv_name,
+              defaultProtocol
+            ).qualifiedName(),
+            value: action.value._text,
+            description:
+              (action.description && action.description._text) || undefined
+          }
+        });
+      } else if (type === "open_webpage") {
+        processedActions.actions.push({
+          type: OPEN_WEBPAGE,
+          openWebpageInfo: {
+            url: action.url._text,
+            description:
+              (action.description && action.description._text) || undefined
+          }
+        });
+      } else if (type === "open_display") {
+        processedActions.actions.push({
+          type: OPEN_TAB,
+          dynamicInfo: {
+            name: action.file._text,
+            location: actionToLocation(action),
+            description:
+              (action.description && action.description._text) || undefined,
+            file: {
+              path: action.file._text,
+              // TODO: Should probably be accessing properties of the element here
+              macros: {},
+              defaultProtocol: "ca"
+            }
+          }
+        });
+      }
+    } catch (e: any) {
+      log.error(
+        `Could not find action of type ${type} in available actions to convert: ${e.message}`
+      );
+    }
+  });
+
+  return processedActions;
+}
 
 function bobGetTargetWidget(props: any): React.FC {
   const typeid = bobParseType(props);
@@ -260,7 +350,7 @@ export function parseBob(
     actions: [
       "actions",
       (actions: ElementCompact): WidgetActions =>
-        opiParseActions(actions, defaultProtocol)
+        bobParseActions(actions, defaultProtocol)
     ],
     items: ["items", bobParseItems],
     imageFile: ["file", opiParseString],


### PR DESCRIPTION
Actions in bob files were previously parsed by `opiParseActions`, which didn't work due to small differences between actions in opi and bob files. These include:

- The `type` of action is lowercase in bob i.e. "open_display" but uppercase in opi
- bob files use the `target` property to determine if the new screen opens in a tab or in place of the current screen, rather than mode and position
- The path to the file to open is given by the `file` property rather than the `path` property in bob files

I created `bobParseActions` to correctly parse with these differences