### PR TITLE
Fix warnings in bobParser when alarmSensitive border property is missing

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
@@ -107,7 +107,6 @@ describe("opi widget parser", (): void => {
       <y>62</y>
       <width>140</width>
       <height>50</height>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
     </widget>
   </display>`;
   it("parses defaults", (): void => {
@@ -116,6 +115,7 @@ describe("opi widget parser", (): void => {
     expect(widget.precisionFromPv).toEqual(true);
     expect(widget.showUnits).toEqual(true);
     expect(widget.wrapWords).toEqual(true);
+    expect(widget.alarmSensitive).toEqual(true);
   });
 
   const readbackPrecisionUnits = `

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -8,7 +8,6 @@ import {
   opiParseRules,
   opiParsePvName,
   opiParseColor,
-  opiParseAlarmSensitive,
   opiParseString,
   opiParseMacros,
   opiParseBoolean
@@ -149,6 +148,15 @@ function bobParseBorder(props: any): Border {
   } else {
     return Border.NONE;
   }
+}
+
+export function bobParseAlarmSensitive(props: any): boolean {
+  // If property is missing the default is true
+  let alarmSensitive = true;
+  if (props.border_alarm_sensitive !== undefined) {
+    alarmSensitive = opiParseBoolean(props.border_alarm_sensitive);
+  }
+  return alarmSensitive;
 }
 
 function bobParseItems(jsonProp: ElementCompact): string[] {
@@ -329,7 +337,7 @@ const BOB_COMPLEX_PARSERS: ComplexParserDict = {
   type: bobParseType,
   position: bobParsePosition,
   border: bobParseBorder,
-  alarmSensitive: opiParseAlarmSensitive,
+  alarmSensitive: bobParseAlarmSensitive,
   file: bobParseFile
 };
 


### PR DESCRIPTION
While testing a previous change in the bobParser I noticed that I was getting warnings in the console that a property could not be parsed. This didn't cause errors in the application as the property was optional. 

![Screenshot from 2025-02-06 09-16-32](https://github.com/user-attachments/assets/d8bbc8c0-7fb8-48d7-b5e6-aadfb2d20d5c)

The problem is that a BOB file generated from Phoebus by default does not include the `alarm_sensitive_border` property. By default this is assumed to be _true_ and so the property is only added if the user sets it to _false_. 

I've added a separate bobParser version to use instead of the opiParser version. Also updated the tests to make sure the default version is reflected correctly.

TESTING: To test with and without this fix, use a BOB file generated by Phoebus that contains a `TextUpdate` widget.