### PR TITLE
Update GroupBox widget

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -378,7 +378,8 @@ export function parseBob(
     showIndex: ["show_index", opiParseBoolean],
     fallbackSymbol: ["fallback_symbol", opiParseString],
     rotation: ["rotation", bobParseNumber],
-    styleOpt: ["style", bobParseNumber]
+    styleOpt: ["style", bobParseNumber],
+    lineColor: ["line_color", opiParseColor]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -44,7 +44,7 @@ const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   display: "display",
   ellipse: "ellipse",
   embedded: "embeddedDisplay",
-  group: "groupingcontainer",
+  group: "groupbox",
   label: "label",
   led: "led",
   textupdate: "readback",
@@ -377,7 +377,8 @@ export function parseBob(
     initialIndex: ["initial_index", bobParseNumber],
     showIndex: ["show_index", opiParseBoolean],
     fallbackSymbol: ["fallback_symbol", opiParseString],
-    rotation: ["rotation", bobParseNumber]
+    rotation: ["rotation", bobParseNumber],
+    style: ["style", bobParseNumber]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -378,7 +378,7 @@ export function parseBob(
     showIndex: ["show_index", opiParseBoolean],
     fallbackSymbol: ["fallback_symbol", opiParseString],
     rotation: ["rotation", bobParseNumber],
-    style: ["style", bobParseNumber]
+    styleOpt: ["style", bobParseNumber]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -208,7 +208,7 @@ export const EmbeddedDisplay = (
   if (props.border?.style === BorderStyle.GroupBox) {
     return (
       <MacroContext.Provider value={embeddedDisplayMacroContext}>
-        <GroupBoxComponent name={resolvedName} compat={true}>
+        <GroupBoxComponent name={resolvedName} styleOpt={0}>
           {component}
         </GroupBoxComponent>
       </MacroContext.Provider>

--- a/src/ui/widgets/GroupBox/__snapshots__/groupBox.test.tsx.snap
+++ b/src/ui/widgets/GroupBox/__snapshots__/groupBox.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Group Box
     style="width: 100%; height: 100%; position: absolute; padding: 0px 10px 10px 10px; box-sizing: border-box;"
   >
     <fieldset
-      class="MuiBox-root css-198zxrn"
+      class="MuiBox-root css-1ho00z6"
     >
       <legend>
         Test
       </legend>
       <div
-        style="position: relative; overflow: visible;"
+        style="position: relative; overflow: visible; color: black;"
       />
     </fieldset>
   </div>
@@ -25,10 +25,10 @@ exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Line styl
     style="width: 100%; height: 100%; position: absolute; padding: 0px; box-sizing: border-box;"
   >
     <fieldset
-      class="MuiBox-root css-ztfooh"
+      class="MuiBox-root css-1wd2nmm"
     >
       <div
-        style="position: relative; overflow: visible;"
+        style="position: relative; overflow: visible; color: black;"
       />
     </fieldset>
   </div>
@@ -41,15 +41,15 @@ exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Title Bar
     style="width: 100%; height: 100%; position: absolute; padding: 0px; box-sizing: border-box;"
   >
     <fieldset
-      class="MuiBox-root css-ztfooh"
+      class="MuiBox-root css-1wd2nmm"
     >
       <div
-        style="height: 20px; width: 100%; background-color: rgb(0, 0, 0); font-family: Liberation sans,sans-serif; font-weight: normal; font-style: normal; font-size: 1rem; color: rgb(240, 240, 240);"
+        style="height: 20px; width: 100%; background-color: rgb(0, 0, 0); font-family: Liberation sans,sans-serif; font-weight: normal; font-style: normal; font-size: 1rem; text-align: left; color: rgb(0, 0, 0);"
       >
         Title
       </div>
       <div
-        style="position: relative; overflow: visible;"
+        style="position: relative; overflow: visible; color: black;"
       />
     </fieldset>
   </div>
@@ -65,7 +65,7 @@ exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for no style 
       class="MuiBox-root css-m53wvz"
     >
       <div
-        style="position: relative; overflow: visible;"
+        style="position: relative; overflow: visible; color: black;"
       />
     </fieldset>
   </div>

--- a/src/ui/widgets/GroupBox/__snapshots__/groupBox.test.tsx.snap
+++ b/src/ui/widgets/GroupBox/__snapshots__/groupBox.test.tsx.snap
@@ -1,38 +1,73 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<GroupingContainerComponent /> > it matches the snapshot 1`] = `
-<div
-  style={
-    {
-      "backgroundColor": "transparent",
-      "height": "100%",
-      "outline": "1px dotted black",
-      "outlineOffset": "-7px",
-      "width": "100%",
-    }
-  }
->
+exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Group Box style 1`] = `
+<DocumentFragment>
   <div
-    style={
-      {
-        "backgroundColor": "rgba(255,255,255,255)",
-        "fontSize": "13px",
-        "left": "20px",
-        "padding": "0 2px 0 2px",
-        "position": "absolute",
-        "top": "0",
-      }
-    }
+    style="width: 100%; height: 100%; position: absolute; padding: 0px 10px 10px 10px; box-sizing: border-box;"
   >
-    Test
+    <fieldset
+      class="MuiBox-root css-198zxrn"
+    >
+      <legend>
+        Test
+      </legend>
+      <div
+        style="position: relative; overflow: visible;"
+      />
+    </fieldset>
   </div>
+</DocumentFragment>
+`;
+
+exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Line style 1`] = `
+<DocumentFragment>
   <div
-    style={
-      {
-        "padding": "16px",
-        "position": "relative",
-      }
-    }
-  />
-</div>
+    style="width: 100%; height: 100%; position: absolute; padding: 0px; box-sizing: border-box;"
+  >
+    <fieldset
+      class="MuiBox-root css-ztfooh"
+    >
+      <div
+        style="position: relative; overflow: visible;"
+      />
+    </fieldset>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for Title Bar style 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 100%; height: 100%; position: absolute; padding: 0px; box-sizing: border-box;"
+  >
+    <fieldset
+      class="MuiBox-root css-ztfooh"
+    >
+      <div
+        style="height: 20px; width: 100%; background-color: rgb(0, 0, 0); font-family: Liberation sans,sans-serif; font-weight: normal; font-style: normal; font-size: 1rem; color: rgb(240, 240, 240);"
+      >
+        Title
+      </div>
+      <div
+        style="position: relative; overflow: visible;"
+      />
+    </fieldset>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<GroupBoxComponent /> snapshots > it matches the snapshot for no style 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 100%; height: 100%; position: absolute; padding: 0px; box-sizing: border-box;"
+  >
+    <fieldset
+      class="MuiBox-root css-m53wvz"
+    >
+      <div
+        style="position: relative; overflow: visible;"
+      />
+    </fieldset>
+  </div>
+</DocumentFragment>
 `;

--- a/src/ui/widgets/GroupBox/groupBox.test.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.test.tsx
@@ -1,19 +1,42 @@
 import React from "react";
 import { GroupBoxComponent } from "./groupBox";
-import { create } from "react-test-renderer";
 import { Color } from "../../../types/color";
 import { render } from "@testing-library/react";
 
-describe("<GroupingContainerComponent />", (): void => {
-  test("it matches the snapshot", (): void => {
-    const snapshot = create(
-      <GroupBoxComponent name={"Test"} backgroundColor={Color.WHITE} />
+describe("<GroupBoxComponent /> snapshots", (): void => {
+  test("it matches the snapshot for Group Box style", (): void => {
+    const { asFragment } = render(
+      <GroupBoxComponent
+        name={"Test"}
+        backgroundColor={Color.WHITE}
+        styleOpt={0}
+      />
     );
-    expect(snapshot.toJSON()).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
+  test("it matches the snapshot for Title Bar style", (): void => {
+    const { asFragment } = render(
+      <GroupBoxComponent name={"Title"} styleOpt={1} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+  test("it matches the snapshot for Line style", (): void => {
+    const { asFragment } = render(
+      <GroupBoxComponent name={"No Title"} styleOpt={2} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+  test("it matches the snapshot for no style", (): void => {
+    const { asFragment } = render(
+      <GroupBoxComponent name={"None"} styleOpt={3} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});
 
+describe("<GroupBoxComponent />", (): void => {
   test("it renders the title", (): void => {
-    const grouping = <GroupBoxComponent name={"Test"} />;
+    const grouping = <GroupBoxComponent name={"Test"} styleOpt={1} />;
     const { getByText } = render(grouping);
     expect(getByText("Test")).toBeInTheDocument();
   });

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -27,7 +27,7 @@ const GroupBoxProps = {
   backgroundColor: ColorPropOpt,
   foregroundColor: ColorPropOpt,
   font: FontPropOpt,
-  style: IntPropOpt,
+  styleOpt: IntPropOpt,
   transparent: BoolPropOpt
 };
 
@@ -41,7 +41,7 @@ export const GroupBoxComponent = (
     backgroundColor = Color.fromRgba(240, 240, 240),
     foregroundColor = Color.fromRgba(0, 0, 0),
     font = new Font(16),
-    style = 0,
+    styleOpt = 0,
     transparent = false
   } = props;
 
@@ -65,12 +65,12 @@ export const GroupBoxComponent = (
     ...font.css()
   };
 
-  if (style === 0) {
+  if (styleOpt === 0) {
     // Typical group box with label
     outerDivStyle.padding = "10px";
     outerDivStyle.paddingTop = "0px";
     boxStyle.paddingLeft = "8px";
-  } else if (style === 3) {
+  } else if (styleOpt === 3) {
     // No groupbox
     boxStyle.border = "none";
   }
@@ -78,7 +78,7 @@ export const GroupBoxComponent = (
   return (
     <div style={outerDivStyle}>
       <Box component="fieldset" sx={boxStyle}>
-        {style === 1 ? (
+        {styleOpt === 1 ? (
           <div
             style={{
               height: "20px",
@@ -93,7 +93,7 @@ export const GroupBoxComponent = (
         ) : (
           <></>
         )}
-        {style === 0 ? <legend>{props.name}</legend> : <></>}
+        {styleOpt === 0 ? <legend>{props.name}</legend> : <></>}
         <div style={INNER_DIV_STYLE}>{props.children}</div>
       </Box>
     </div>

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -98,6 +98,7 @@ export const GroupBoxComponent = (
 
 const GroupBoxWidgetProps = {
   ...WidgetPropType,
+  ...GroupBoxProps,
   name: StringProp,
   children: ChildrenPropOpt
 };

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -8,14 +8,23 @@ import {
   ChildrenPropOpt,
   InferWidgetProps,
   ColorPropOpt,
-  BoolPropOpt
+  BoolPropOpt,
+  FontPropOpt,
+  IntPropOpt
 } from "../propTypes";
+import { Font } from "../../../types/font";
+import { Color } from "../../../types/color";
+import Box from "@mui/material/Box";
 
 const GroupBoxProps = {
   name: StringProp,
   children: ChildrenPropOpt,
   backgroundColor: ColorPropOpt,
-  compat: BoolPropOpt
+  foregroundColor: ColorPropOpt,
+  font: FontPropOpt,
+  compat: BoolPropOpt,
+  boxStyle: IntPropOpt,
+  transparent: BoolPropOpt
 };
 
 // Widget that renders a group-box style border showing the name prop.
@@ -24,47 +33,66 @@ const GroupBoxProps = {
 export const GroupBoxComponent = (
   props: InferWidgetProps<typeof GroupBoxProps>
 ): JSX.Element => {
-  const { compat = false } = props;
+  const {
+    compat = false,
+    backgroundColor = Color.fromRgba(240, 240, 240),
+    foregroundColor = Color.fromRgba(0, 0, 0),
+    font = new Font(16),
+    boxStyle = 0,
+    transparent = false
+  } = props;
+
   // Manually render a group-box style border.
   const innerDivStyle: CSSProperties = {
     position: "relative",
-    padding: "16px"
+    overflow: "visible"
   };
+  const style: CSSProperties = {
+    width: "100%",
+    height: "100%",
+    padding: "0px",
+    paddingLeft: "8px",
+    border: "1px solid black",
+    whiteSpace: "nowrap",
+    overflow: "visible",
+    backgroundColor: transparent ? "transparent" : backgroundColor.toString(),
+    color: foregroundColor.toString(),
+    ...font.css()
+  };
+
+  if (boxStyle === 0) {
+    // Typical group box with label
+  } else if (boxStyle === 1) {
+    // Title bar
+
+  } else if (boxStyle === 2) {
+    // Border only
+
+  } else {
+    // None
+    style.border = "none"
+
+  }
   // Specific styling to match the group boxes in opibuilder.
   if (compat) {
-    innerDivStyle.padding = undefined;
-    innerDivStyle.top = "16px";
-    innerDivStyle.left = "16px";
-    innerDivStyle.height = "calc(100% - 32px)";
-    innerDivStyle.width = "calc(100% - 32px)";
-    innerDivStyle.overflow = "hidden";
+    innerDivStyle.paddingLeft = "5px";
+    innerDivStyle.height = "100%";
+    innerDivStyle.width = "100%";
+    innerDivStyle.overflow = "visible";
   }
-  // Dimensions match those in the opibuilder groupbox borders.
+
   return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        outline: "1px dotted black",
-        outlineOffset: "-7px",
-        backgroundColor: "transparent"
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          top: "0",
-          left: "20px",
-          fontSize: "13px",
-          padding: "0 2px 0 2px",
-          backgroundColor:
-            props.backgroundColor?.toString() ?? "rgb(200,200,200)"
-        }}
-      >
-        {props.name}
-      </div>
-      <div style={innerDivStyle}>{props.children}</div>
+    <div style={{
+      padding: "10px", paddingTop: "0px", width: "100%",
+      height: "100%",
+      position: "absolute",
+    }}>
+      <Box component="fieldset" sx={style}>
+        <legend>{props.name}</legend>
+        <div style={innerDivStyle}>{props.children}</div>
+      </Box>
     </div>
+
   );
 };
 

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -16,14 +16,18 @@ import { Font } from "../../../types/font";
 import { Color } from "../../../types/color";
 import Box from "@mui/material/Box";
 
+const INNER_DIV_STYLE: CSSProperties = {
+  position: "relative",
+  overflow: "visible"
+};
+
 const GroupBoxProps = {
   name: StringProp,
   children: ChildrenPropOpt,
   backgroundColor: ColorPropOpt,
   foregroundColor: ColorPropOpt,
   font: FontPropOpt,
-  compat: BoolPropOpt,
-  boxStyle: IntPropOpt,
+  style: IntPropOpt,
   transparent: BoolPropOpt
 };
 
@@ -34,24 +38,25 @@ export const GroupBoxComponent = (
   props: InferWidgetProps<typeof GroupBoxProps>
 ): JSX.Element => {
   const {
-    compat = false,
     backgroundColor = Color.fromRgba(240, 240, 240),
     foregroundColor = Color.fromRgba(0, 0, 0),
     font = new Font(16),
-    boxStyle = 0,
+    style = 0,
     transparent = false
   } = props;
 
-  // Manually render a group-box style border.
-  const innerDivStyle: CSSProperties = {
-    position: "relative",
-    overflow: "visible"
+  const outerDivStyle: CSSProperties = {
+    width: "100%",
+    height: "100%",
+    position: "absolute",
+    padding: "0px",
+    boxSizing: "border-box"
   };
-  const style: CSSProperties = {
+
+  const boxStyle: CSSProperties = {
     width: "100%",
     height: "100%",
     padding: "0px",
-    paddingLeft: "8px",
     border: "1px solid black",
     whiteSpace: "nowrap",
     overflow: "visible",
@@ -60,39 +65,38 @@ export const GroupBoxComponent = (
     ...font.css()
   };
 
-  if (boxStyle === 0) {
+  if (style === 0) {
     // Typical group box with label
-  } else if (boxStyle === 1) {
-    // Title bar
-
-  } else if (boxStyle === 2) {
-    // Border only
-
-  } else {
-    // None
-    style.border = "none"
-
-  }
-  // Specific styling to match the group boxes in opibuilder.
-  if (compat) {
-    innerDivStyle.paddingLeft = "5px";
-    innerDivStyle.height = "100%";
-    innerDivStyle.width = "100%";
-    innerDivStyle.overflow = "visible";
+    outerDivStyle.padding = "10px";
+    outerDivStyle.paddingTop = "0px";
+    boxStyle.paddingLeft = "8px";
+  } else if (style === 3) {
+    // No groupbox
+    boxStyle.border = "none";
   }
 
   return (
-    <div style={{
-      padding: "10px", paddingTop: "0px", width: "100%",
-      height: "100%",
-      position: "absolute",
-    }}>
-      <Box component="fieldset" sx={style}>
-        <legend>{props.name}</legend>
-        <div style={innerDivStyle}>{props.children}</div>
+    <div style={outerDivStyle}>
+      <Box component="fieldset" sx={boxStyle}>
+        {style === 1 ? (
+          <div
+            style={{
+              height: "20px",
+              width: "100%",
+              backgroundColor: foregroundColor.toString(),
+              ...font.css(),
+              color: backgroundColor.toString()
+            }}
+          >
+            {props.name}
+          </div>
+        ) : (
+          <></>
+        )}
+        {style === 0 ? <legend>{props.name}</legend> : <></>}
+        <div style={INNER_DIV_STYLE}>{props.children}</div>
       </Box>
     </div>
-
   );
 };
 

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -4,13 +4,13 @@ import { Widget } from "../widget";
 import { WidgetPropType } from "../widgetProps";
 import { registerWidget } from "../register";
 import {
-  StringProp,
   ChildrenPropOpt,
   InferWidgetProps,
   ColorPropOpt,
   BoolPropOpt,
   FontPropOpt,
-  IntPropOpt
+  IntPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { Font } from "../../../types/font";
 import { Color } from "../../../types/color";
@@ -18,14 +18,16 @@ import Box from "@mui/material/Box";
 
 const INNER_DIV_STYLE: CSSProperties = {
   position: "relative",
-  overflow: "visible"
+  overflow: "visible",
+  color: "black"
 };
 
 const GroupBoxProps = {
-  name: StringProp,
+  name: StringPropOpt,
   children: ChildrenPropOpt,
   backgroundColor: ColorPropOpt,
   foregroundColor: ColorPropOpt,
+  lineColor: ColorPropOpt,
   font: FontPropOpt,
   styleOpt: IntPropOpt,
   transparent: BoolPropOpt
@@ -40,6 +42,7 @@ export const GroupBoxComponent = (
   const {
     backgroundColor = Color.fromRgba(240, 240, 240),
     foregroundColor = Color.fromRgba(0, 0, 0),
+    lineColor = Color.fromRgba(0, 0, 0),
     font = new Font(16),
     styleOpt = 0,
     transparent = false
@@ -57,7 +60,7 @@ export const GroupBoxComponent = (
     width: "100%",
     height: "100%",
     padding: "0px",
-    border: "1px solid black",
+    border: "1px solid " + lineColor.toString(),
     whiteSpace: "nowrap",
     overflow: "visible",
     backgroundColor: transparent ? "transparent" : backgroundColor.toString(),
@@ -75,6 +78,11 @@ export const GroupBoxComponent = (
     boxStyle.border = "none";
   }
 
+  let name = "";
+  if (props.name !== undefined) {
+    name = props.name;
+  }
+
   return (
     <div style={outerDivStyle}>
       <Box component="fieldset" sx={boxStyle}>
@@ -83,17 +91,18 @@ export const GroupBoxComponent = (
             style={{
               height: "20px",
               width: "100%",
-              backgroundColor: foregroundColor.toString(),
+              backgroundColor: lineColor.toString(),
               ...font.css(),
-              color: backgroundColor.toString()
+              textAlign: "left",
+              color: foregroundColor.toString()
             }}
           >
-            {props.name}
+            {name}
           </div>
         ) : (
           <></>
         )}
-        {styleOpt === 0 ? <legend>{props.name}</legend> : <></>}
+        {styleOpt === 0 ? <legend>{name}</legend> : <></>}
         <div style={INNER_DIV_STYLE}>{props.children}</div>
       </Box>
     </div>
@@ -103,7 +112,7 @@ export const GroupBoxComponent = (
 const GroupBoxWidgetProps = {
   ...WidgetPropType,
   ...GroupBoxProps,
-  name: StringProp,
+  name: StringPropOpt,
   children: ChildrenPropOpt
 };
 


### PR DESCRIPTION
I have updated the GroupBox widget appearance, and pointed the widget mapping to correctly use GroupBox instead of GroupingContainer for bob files. None of the opi behaviour should be affected by these changes.

Changes:
- Phoebus group boxes come in 4 styles - Group Box, Title Bar, Line and None. These are now all included. The `style` property is parsed as `styleOpt`, in order to prevent confusion when passing the prop to a component (not doing so triggers an eslint warning `Style prop value must be an object`)
- Removed the `compat` property and set the style for GroupBox EmbeddedDisplays to the default groupbox style. This should give the same appearance as before
- Props were not being passed to the widget correctly due to missing GroupBoxProps in GroupBoxWidgetProps. This has now been fixed
- Updated tests