### PR TITLE
Modify and export addPage widget actions

### DIFF
--- a/src/misc/fileContext.tsx
+++ b/src/misc/fileContext.tsx
@@ -53,7 +53,8 @@ export interface TabState {
 export function addPage(
   pageState: PageState,
   location: string,
-  desc: FileDescription
+  desc: FileDescription,
+  pathname?: string
 ): PageState {
   const pagesCopy = { ...pageState };
   pagesCopy[location] = desc;
@@ -171,7 +172,11 @@ export function selectTab(
 export type FileContextType = {
   pageState: PageState;
   tabState: TabState;
-  addPage: (location: string, fileDesc: FileDescription) => void;
+  addPage: (
+    location: string,
+    fileDesc: FileDescription,
+    pathname?: string
+  ) => void;
   removePage: (location: string, fileDesc?: FileDescription) => void;
   addTab: (
     location: string,
@@ -238,9 +243,13 @@ export const FileProvider: React.FC<FileProviderProps> = (
   const fileContext = {
     pageState,
     tabState,
-    addPage: (location: string, fileDesc: FileDescription): void => {
+    addPage: (
+      location: string,
+      fileDesc: FileDescription,
+      pathname?: string
+    ): void => {
       const newPageState = addPage(pageState, location, fileDesc);
-      history.push(history.location.pathname, {
+      history.push(pathname ? pathname : history.location.pathname, {
         pageState: newPageState,
         tabState: history.location.state?.tabState ?? tabState
       });

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,3 +1,3 @@
 export { onRenderCallback } from "./profilerCallback";
-export { FileProvider } from "./fileContext";
+export { FileProvider, FileContext } from "./fileContext";
 export { OutlineContext, OutlineProvider } from "./outlineContext";

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -36,6 +36,7 @@ export { TabContainer } from "./Tabs/tabContainer";
 export { DynamicTabs } from "./Tabs/dynamicTabs";
 export { XYPlot } from "./XYPlot/xyPlot";
 export { Webcam } from "./Webcam/webcam";
+export { executeAction } from "./widgetActions";
 
 // By importing and calling this function you ensure all the
 // above widgets are imported and thus registered.

--- a/src/ui/widgets/widgetActions.ts
+++ b/src/ui/widgets/widgetActions.ts
@@ -120,14 +120,15 @@ export const getActionDescription = (action: WidgetAction): string => {
 export const openPage = (
   action: DynamicAction,
   fileContext?: FileContextType,
-  parentMacros?: MacroMap
+  parentMacros?: MacroMap,
+  pathname?: string
 ): void => {
   const { location, file } = action.dynamicInfo;
   file.macros = {
     ...(parentMacros ?? {}),
     ...file.macros
   };
-  fileContext?.addPage(location, file);
+  fileContext?.addPage(location, file, pathname);
 };
 
 export const closePage = (
@@ -163,12 +164,13 @@ export const executeAction = (
   action: WidgetAction,
   files?: FileContextType,
   exitContext?: ExitContextType,
-  parentMacros?: MacroMap
+  parentMacros?: MacroMap,
+  pathname?: string
 ): void => {
   switch (action.type) {
     case OPEN_PAGE:
       if (files) {
-        openPage(action, files, parentMacros);
+        openPage(action, files, parentMacros, pathname);
       } else {
         log.error("Tried to open a page but no file context passed");
       }


### PR DESCRIPTION
I implemented these changes to come up with a solution to issues I faced when creating a client application that opens and displays files.

Suggested changes:

- Allow new files to be opened at a new URL if wanted. Currently new files are opened at the same address, but a new entry is added to the history. This allows you to traverse file history but not customise URL based on the currently displayed file. Now you can optionally pass a pathname to open your new screen at. It might be worth also adding this to the removePage option, I'd appreciate any opinions?
- Export the executeAction hook so that non cs-web-lib components can trigger open/close page/tab events. Currently, actions such as opening a screen can only be called from inside an existing screen (either a .bob file or a json screen). This seems quite limited if we want to display dynamic .bob files as part of a larger non cs-web-lib application

To test these changes, you can clone https://github.com/DiamondLightSource/daedalus and use a local build of cs-web-lib with these changes. You should be able to see with these changes how .bob files can be opened through the .bob file screens themselves, but also through a menubar and breadcrumbs trail, with the URL changing when a new file is opened. 

I think overall the structure of adding tabs/pages needs an overhaul, but that would be better done at a separate time once we're sure what approach we want to take with it. For now, these changes expand the use of cs-web-lib while not changing the behaviour.