### PR TITLE
Replace 'x' image with unicode text and fix font scaling

### DIFF
--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -51,6 +51,7 @@ export const DynamicPageComponent = (
           width: "100%",
           border: "1px solid black",
           minHeight: "100px",
+          fontSize: "0.625rem",
           ...style
         }}
       >
@@ -82,7 +83,8 @@ export const DynamicPageComponent = (
             <ActionButton
               position={new RelativePosition("25px", "25px")}
               backgroundColor={new Color("var(--light-background)")}
-              foregroundColor={new Color("#ffffff")}
+              foregroundColor={new Color("#000000")}
+              text={"\u2715"}
               actions={{
                 executeAsOne: false,
                 actions: [
@@ -97,7 +99,6 @@ export const DynamicPageComponent = (
                   }
                 ]
               }}
-              image="/img/x.png"
             />
           </div>
         </div>


### PR DESCRIPTION
- Following a fix of the font scaling the font used to signal that a file had not been loaded was too large for the DynamicPage. This is just something I missed earlier and so easily fixable

    Before:
    ![Screenshot from 2025-03-04 15-15-26](https://github.com/user-attachments/assets/f61c0717-7fca-42fb-894e-00270bad5ffa)
    After:
    ![Screenshot from 2025-03-04 15-11-53](https://github.com/user-attachments/assets/15d12d1a-263e-4047-8ca9-c814e9068ac7)

- The /img/x.png is used to fill the 'close' actionbutton within a DynamicPage. This image was not actually part of the library and relied on the client app having it. This image was only in cs-web-proto (as that was where it originated) but if the image was not in the client app then you would get an empty action button. What's more, it's not easy to include an image into a library - in fact I couldn't get this to work within our current rollup configuration. So instead I opted to use a unicode character which yields the same effect.
 
    Before:  ![Screenshot from 2025-03-04 15-14-58](https://github.com/user-attachments/assets/848a1fed-699c-46fe-a673-c3c6ad10994e) After: ![Screenshot from 2025-03-04 15-12-34](https://github.com/user-attachments/assets/d45cd409-cea3-49b2-bbd3-1234af79bf5f)
