### PR TITLE
Fix image stretch to fit behaviour

### DIFF
--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -38,17 +38,7 @@ export const ImageComponent = (
     }
   };
 
-  let imageHeight: string | undefined = undefined;
-  let imageWidth: string | undefined = undefined;
   const overflow = props.overflow ? "visible" : "hidden";
-  if (props.stretchToFit) {
-    imageWidth = "100%";
-    imageHeight = "100%";
-  } else if (props.fitToWidth) {
-    imageWidth = "100%";
-  } else if (props.fitToHeight) {
-    imageHeight = "100%";
-  }
 
   const style: CSSProperties = {
     ...commonCss(props as any),
@@ -75,8 +65,8 @@ export const ImageComponent = (
         src={imageFileName}
         alt={props.alt || undefined}
         style={{
-          width: imageWidth,
-          height: imageHeight,
+          width: "100%",
+          height: "100%",
           display: "block",
           transform: `rotate(${rotation}deg) scaleX(${
             flipHorizontal ? -1 : 1

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -54,8 +54,8 @@ export const ImageComponent = (
     ...commonCss(props as any),
     overflow,
     textAlign: "left",
-    width: imageWidth,
-    height: imageHeight
+    width: "100%",
+    height: "100%"
   };
 
   // Should we be refreshing image instead of using cache

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -81,7 +81,8 @@ export const ImageComponent = (
           transform: `rotate(${rotation}deg) scaleX(${
             flipHorizontal ? -1 : 1
           }) scaleY(${flipVertical ? -1 : 1})`,
-          objectFit: props.stretchToFit ? "fill" : "none"
+          objectFit: props.stretchToFit ? "fill" : "none",
+          objectPosition: "top left"
         }}
       />
     </div>

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`
   >
     <img
       src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -20,7 +20,7 @@ exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
   >
     <img
       src="img 3.svg"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -33,7 +33,7 @@ exports[`<Symbol /> from .bob file > matches snapshot (with rotation) 1`] = `
   >
     <img
       src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -46,7 +46,7 @@ exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
   >
     <img
       src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -59,7 +59,7 @@ exports[`<Symbol /> from .opi file > matches snapshot (with rotation) 1`] = `
   >
     <img
       src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -72,7 +72,7 @@ exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
   >
     <img
       src="img 1.gif"
-      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill;"
+      style="width: 100%; height: 100%; display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
     />
   </div>
   <div
@@ -84,7 +84,7 @@ exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
     >
       <div
         class="Label _Label_c35983"
-        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start;"
+        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start; object-position: top left;"
       >
         <span>
            Fake value 

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
     >
       <div
         class="Label _Label_c35983"
-        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start; object-position: top left;"
+        style="background-color: transparent; cursor: default; justify-content: flex-start; align-items: flex-start;"
       >
         <span>
            Fake value 


### PR DESCRIPTION
I've added an objectPosition attribute, set to "top left", to the returned <img> component. I believe the default behaviour is for this to be set to "center" which would explain the behaviour. I don't if it would be better for there to be an option for this?