### PR TITLE
Update widget rules not applying to nested properties

### DIFF
--- a/src/types/position.ts
+++ b/src/types/position.ts
@@ -70,6 +70,8 @@ export class AbsolutePosition {
 }
 
 export class RelativePosition {
+  public x: string;
+  public y: string;
   public width: string;
   public height: string;
   public margin: string;
@@ -79,6 +81,8 @@ export class RelativePosition {
   public minHeight: string;
 
   public constructor(
+    x = "",
+    y = "",
     width = "",
     height = "",
     margin = "",
@@ -87,6 +91,8 @@ export class RelativePosition {
     maxWidth = "",
     minHeight = ""
   ) {
+    this.x = x;
+    this.y = y;
     this.width = width;
     this.height = height;
     this.margin = margin;

--- a/src/ui/hooks/useRules.ts
+++ b/src/ui/hooks/useRules.ts
@@ -10,6 +10,7 @@ import { AlarmQuality, DType } from "../../types/dtypes";
 import { SubscriptionType } from "../../connection/plugin";
 import { Border, BorderStyle } from "../../types/border";
 import { Color } from "../../types/color";
+import { opiParseColor } from "../widgets/EmbeddedDisplay/opiParser";
 
 // See https://stackoverflow.com/questions/54542318/using-an-enum-as-a-dictionary-key
 type EnumDictionary<T extends string | symbol | number, U> = {
@@ -90,7 +91,38 @@ export function useRules(props: AnyProps): AnyProps {
           // Not 'output expression': set the prop to the provided value.
           log.debug("Expression matched");
           if (!outExp) {
-            newProps[prop] = exp.convertedValue;
+            switch (prop) {
+              case "border_width":
+                if (newProps.border) {
+                  newProps["border"]["width"] = Number(exp.value._text);
+                } else {
+                  newProps.border = new Border(
+                    BorderStyle.None,
+                    Color.BLACK,
+                    Number(exp.value._text)
+                  );
+                }
+                break;
+              case "border_color":
+                if (newProps.border) {
+                  newProps["border"]["color"] = opiParseColor(exp.value);
+                } else {
+                  newProps.border = new Border(
+                    BorderStyle.None,
+                    opiParseColor(exp.value),
+                    0
+                  );
+                }
+                break;
+              case "x":
+                newProps["position"]["x"] = `${exp.value._text}px`;
+                break;
+              case "y":
+                newProps["position"]["y"] = `${exp.value._text}px`;
+                break;
+              default:
+                newProps[prop] = exp.convertedValue;
+            }
             log.debug("Output value");
             log.debug(newProps);
           } else {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -400,6 +400,8 @@ export function parseBob(
   );
 
   displayWidget.position = new RelativePosition(
+    displayWidget.position.x,
+    displayWidget.position.y,
     displayWidget.position.width,
     displayWidget.position.height
   );

--- a/src/ui/widgets/EmbeddedDisplay/jsonParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/jsonParser.ts
@@ -44,6 +44,8 @@ function jsonParsePosition(props: Record<string, string>): Position {
     );
   } else {
     return new RelativePosition(
+      props.x,
+      props.y,
       props.width,
       props.height,
       props.margin,

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
@@ -21,7 +21,7 @@ describe("opi widget parser", (): void => {
   it("parses a display widget", (): void => {
     const displayWidget = parseOpi(displayString, "ca", PREFIX);
     expect(displayWidget.position).toEqual(
-      new RelativePosition("30px", "40px")
+      new RelativePosition("0px", "0px", "30px", "40px")
     );
   });
   const labelString = `

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -876,6 +876,8 @@ export function parseOpi(
 
   displayWidget.position = new RelativePosition(
     // Handle generated display widgets with no width or height.
+    displayWidget.position?.x,
+    displayWidget.position?.y,
     displayWidget.position?.width,
     displayWidget.position?.height
   );


### PR DESCRIPTION
Added x and y fields to the RelativePosition prop as Widgets expects a PositionProp, which can either be RelativePosition or AbsolutePosition, and therefore it wasn't possible to change the x and y fields of the PositionProp because they may not always exist. 