### PR TITLE
81 pv formulae not supported

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -28,6 +28,7 @@ if (PVWS_SOCKET !== undefined) {
   plugins.unshift(["sim://", pvws]);
   plugins.unshift(["ssim://", pvws]);
   plugins.unshift(["dev://", pvws]);
+  plugins.unshift(["eq://", pvws]);
 }
 const connection = new ConnectionForwarder(plugins);
 

--- a/src/types/pv.test.ts
+++ b/src/types/pv.test.ts
@@ -13,4 +13,8 @@ describe("PV", (): void => {
     const pv = PV.parse("pvName");
     expect(pv).toEqual(new PV("pvName", "ca"));
   });
+  it("ignores nested pv", (): void => {
+    const pv = PV.parse("=3+4*`sim://ramp`");
+    expect(pv.qualifiedName()).toEqual("eq://3+4*`sim://ramp`");
+  });
 });

--- a/src/types/pv.ts
+++ b/src/types/pv.ts
@@ -56,7 +56,7 @@ export class PV {
     ) {
       return this.name;
       // In case the name has been substituted with another formula
-    } else if (this.name.startsWith("eq://")) {
+    } else if (this.name.startsWith("eq://") || this.name.startsWith("=")) {
       return this.name;
     } else {
       return `${this.protocol}${PV.DELIMITER}${this.name}`;

--- a/src/types/pv.ts
+++ b/src/types/pv.ts
@@ -56,8 +56,10 @@ export class PV {
     ) {
       return this.name;
       // In case the name has been substituted with another formula
-    } else if (this.name.startsWith("eq://") || this.name.startsWith("=")) {
+    } else if (this.name.startsWith("eq://")) {
       return this.name;
+    } else if (this.name.startsWith("=")) {
+      return this.name.replace("=", "eq://");
     } else {
       return `${this.protocol}${PV.DELIMITER}${this.name}`;
     }

--- a/src/types/pv.ts
+++ b/src/types/pv.ts
@@ -49,7 +49,14 @@ export class PV {
     // This can happen if the name is substituted by a macro
     // after the PV object has been created.
     // Need to make sure that the PV.DELIMITER is not associated with a nested PV.
-    if (this.name.includes(PV.DELIMITER) && !this.name.includes("`")) {
+    if (
+      this.name.includes(PV.DELIMITER) &&
+      !this.name.includes("`") &&
+      !this.name.includes("'")
+    ) {
+      return this.name;
+      // In case the name has been substituted with another formula
+    } else if (this.name.startsWith("eq://")) {
       return this.name;
     } else {
       return `${this.protocol}${PV.DELIMITER}${this.name}`;


### PR DESCRIPTION
PV parser has been updated to correctly parse PV formulae and to parse PV starting with "=" to start with "eq://". "eq://" has been added to list of plugins in store.ts to enable formulae subscribe requests.