### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/src/connection/pvws.ts
+++ b/src/connection/pvws.ts
@@ -107,11 +107,8 @@ function pvwsToDType(data: any): DType {
   }
 
   let dtime = undefined;
-  if (data.seconds) {
-    const datetime = new Date(0);
-    datetime.setSeconds(data.seconds);
-    dtime = new DTime(datetime);
-  }
+  if (data.seconds) dtime = new DTime(new Date(data.seconds * 1000));
+
 
   let stringVal = undefined;
   if (data.text !== undefined) {

--- a/src/connection/pvws.ts
+++ b/src/connection/pvws.ts
@@ -109,7 +109,6 @@ function pvwsToDType(data: any): DType {
   let dtime = undefined;
   if (data.seconds) dtime = new DTime(new Date(data.seconds * 1000));
 
-
   let stringVal = undefined;
   if (data.text !== undefined) {
     stringVal = data.text;

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -18,7 +18,10 @@ import {
   BorderPropOpt,
   BoolPropOpt
 } from "../propTypes";
-import { EmbeddedDisplay, EmbeddedDisplayPropsExtra } from "../EmbeddedDisplay/embeddedDisplay";
+import {
+  EmbeddedDisplay,
+  EmbeddedDisplayPropsExtra
+} from "../EmbeddedDisplay/embeddedDisplay";
 import { Color } from "../../../types/color";
 import { RelativePosition } from "../../../types/position";
 import { ExitFileContext, FileContext } from "../../../misc/fileContext";
@@ -28,13 +31,12 @@ const DynamicPageProps = {
   location: StringProp,
   border: BorderPropOpt,
   showCloseButton: BoolPropOpt,
-  scroll: BoolPropOpt,
+  scroll: BoolPropOpt
 };
 
 // Generic display widget to put other things inside
 export const DynamicPageComponent = (
-  props: InferWidgetProps<typeof DynamicPageProps>  &
-      EmbeddedDisplayPropsExtra
+  props: InferWidgetProps<typeof DynamicPageProps> & EmbeddedDisplayPropsExtra
 ): JSX.Element => {
   const theme = props.theme || phoebusTheme;
   const style = commonCss(props);

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -18,24 +18,25 @@ import {
   BorderPropOpt,
   BoolPropOpt
 } from "../propTypes";
-import { EmbeddedDisplay } from "../EmbeddedDisplay/embeddedDisplay";
+import { EmbeddedDisplay, EmbeddedDisplayPropsExtra } from "../EmbeddedDisplay/embeddedDisplay";
 import { Color } from "../../../types/color";
 import { RelativePosition } from "../../../types/position";
 import { ExitFileContext, FileContext } from "../../../misc/fileContext";
-import { useTheme } from "@mui/material";
+import { phoebusTheme } from "../../../phoebusTheme";
 
 const DynamicPageProps = {
   location: StringProp,
   border: BorderPropOpt,
   showCloseButton: BoolPropOpt,
-  scroll: BoolPropOpt
+  scroll: BoolPropOpt,
 };
 
 // Generic display widget to put other things inside
 export const DynamicPageComponent = (
-  props: InferWidgetProps<typeof DynamicPageProps>
+  props: InferWidgetProps<typeof DynamicPageProps>  &
+      EmbeddedDisplayPropsExtra
 ): JSX.Element => {
-  const theme = useTheme();
+  const theme = props.theme || phoebusTheme;
   const style = commonCss(props);
   const fileContext = useContext(FileContext);
 

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -177,7 +177,7 @@ export const EmbeddedDisplay = (
       type: "display",
       position: props.position,
       backgroundColor:
-        description.backgroundColor ?? new Color("rgb(200,200,200"),
+        description.backgroundColor ?? new Color("rgb(255,255,255"),
       border:
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
       overflow: overflow,

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -33,7 +33,12 @@ const ImageProps = {
 export const ImageComponent = (
   props: InferWidgetProps<typeof ImageProps>
 ): JSX.Element => {
-  const { rotation = 0, flipHorizontal, flipVertical, stretchToFit = false } = props;
+  const {
+    rotation = 0,
+    flipHorizontal,
+    flipVertical,
+    stretchToFit = false
+  } = props;
 
   const onClick = (event: React.MouseEvent<HTMLDivElement>): void => {
     if (props.onClick) {
@@ -41,7 +46,6 @@ export const ImageComponent = (
     }
   };
 
-  console.log(stretchToFit)
   const overflow = props.overflow ? "visible" : "hidden";
 
   const style: CSSProperties = {

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -9,7 +9,8 @@ import {
   StringPropOpt,
   FloatPropOpt,
   FuncPropOpt,
-  MacrosPropOpt
+  MacrosPropOpt,
+  ColorPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 
@@ -24,13 +25,15 @@ const ImageProps = {
   flipHorizontal: BoolPropOpt,
   flipVertical: BoolPropOpt,
   onClick: FuncPropOpt,
-  overflow: BoolPropOpt
+  overflow: BoolPropOpt,
+  backgroundColor: ColorPropOpt,
+  transparent: BoolPropOpt
 };
 
 export const ImageComponent = (
   props: InferWidgetProps<typeof ImageProps>
 ): JSX.Element => {
-  const { rotation = 0, flipHorizontal, flipVertical } = props;
+  const { rotation = 0, flipHorizontal, flipVertical, stretchToFit = false } = props;
 
   const onClick = (event: React.MouseEvent<HTMLDivElement>): void => {
     if (props.onClick) {
@@ -38,6 +41,7 @@ export const ImageComponent = (
     }
   };
 
+  console.log(stretchToFit)
   const overflow = props.overflow ? "visible" : "hidden";
 
   const style: CSSProperties = {
@@ -69,7 +73,7 @@ export const ImageComponent = (
           transform: `rotate(${rotation}deg) scaleX(${
             flipHorizontal ? -1 : 1
           }) scaleY(${flipVertical ? -1 : 1})`,
-          objectFit: props.stretchToFit ? "fill" : "none",
+          objectFit: stretchToFit ? "fill" : "none",
           objectPosition: "top left"
         }}
       />

--- a/src/ui/widgets/Readback/__snapshots__/readback.test.tsx.snap
+++ b/src/ui/widgets/Readback/__snapshots__/readback.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Readback /> > alarm-sensitive foreground colour 1`] = `
 <DocumentFragment>
   <div
-    class="MuiFormControl-root MuiTextField-root css-1ahahy7-MuiFormControl-root-MuiTextField-root"
+    class="MuiFormControl-root MuiTextField-root css-zlfaez-MuiFormControl-root-MuiTextField-root"
   >
     <div
       class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline Mui-readOnly MuiInputBase-readOnly css-1cvskbr-MuiInputBase-root-MuiOutlinedInput-root"
@@ -13,6 +13,7 @@ exports[`<Readback /> > alarm-sensitive foreground colour 1`] = `
         class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline Mui-readOnly MuiInputBase-readOnly css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
         id=":r5:"
         readonly=""
+        style="height: 0px; overflow: hidden;"
       >
         hello
       </textarea>

--- a/src/ui/widgets/Readback/readback.tsx
+++ b/src/ui/widgets/Readback/readback.tsx
@@ -193,7 +193,6 @@ export const ReadbackComponent = (
       disabled={!enabled}
       value={displayedValue}
       multiline={wrapWords}
-      maxRows={"auto"}
       variant="outlined"
       slotProps={{
         input: {
@@ -212,10 +211,12 @@ export const ReadbackComponent = (
         "& .MuiInputBase-input": {
           textAlign: textAlign,
           font: font,
-          lineHeight: 1
         },
         "& .MuiInputBase-root": {
+          justifyContent: alignmentV,
+          flexDirection: "column",
           alignItems: alignmentV,
+          overflow: "hidden",
           color: foregroundColor,
           backgroundColor: backgroundColor
         },

--- a/src/ui/widgets/Readback/readback.tsx
+++ b/src/ui/widgets/Readback/readback.tsx
@@ -210,7 +210,7 @@ export const ReadbackComponent = (
         },
         "& .MuiInputBase-input": {
           textAlign: textAlign,
-          font: font,
+          font: font
         },
         "& .MuiInputBase-root": {
           justifyContent: alignmentV,

--- a/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
+++ b/src/ui/widgets/Symbol/__snapshots__/symbol.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
-      src="https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg"
-      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
+      src="https://cs-web-symbol.diamond.ac.uk/catalogue/default_symbol.png"
+      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: none; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -16,11 +16,11 @@ exports[`<Symbol /> from .bob file > matches snapshot (using fallback symbol) 1`
 exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 3.svg"
-      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
+      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: none; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -29,11 +29,11 @@ exports[`<Symbol /> from .bob file > matches snapshot (with index) 1`] = `
 exports[`<Symbol /> from .bob file > matches snapshot (with rotation) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
-      style="display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
+      style="display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: none; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -42,11 +42,11 @@ exports[`<Symbol /> from .bob file > matches snapshot (with rotation) 1`] = `
 exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
-      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
+      style="display: block; transform: rotate(0deg) scaleX(1) scaleY(1); object-fit: none; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -55,11 +55,11 @@ exports[`<Symbol /> from .bob file > matches snapshot (without index) 1`] = `
 exports[`<Symbol /> from .opi file > matches snapshot (with rotation) 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"
-      style="display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: fill; object-position: top left;"
+      style="display: block; transform: rotate(45deg) scaleX(1) scaleY(1); object-fit: none; object-position: top left;"
     />
   </div>
 </DocumentFragment>
@@ -68,7 +68,7 @@ exports[`<Symbol /> from .opi file > matches snapshot (with rotation) 1`] = `
 exports[`<Symbol /> from .opi file > matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="overflow: visible; text-align: left; width: 100%; height: 100%;"
+    style="background-color: transparent; overflow: visible; text-align: left; width: 100%; height: 100%;"
   >
     <img
       src="img 1.gif"

--- a/src/ui/widgets/Symbol/symbol.tsx
+++ b/src/ui/widgets/Symbol/symbol.tsx
@@ -70,7 +70,7 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
     showIndex = false,
     arrayIndex = 0,
     initialIndex = 0,
-    fallbackSymbol = "https://cs-web-symbol.diamond.ac.uk/catalogue/default.svg",
+    fallbackSymbol = "https://cs-web-symbol.diamond.ac.uk/catalogue/default_symbol.png",
     transparent = true,
     backgroundColor = "white",
     showBooleanLabel = false,
@@ -151,9 +151,10 @@ export const SymbolComponent = (props: SymbolComponentProps): JSX.Element => {
     <>
       <ImageComponent
         {...props}
+        transparent
         imageFile={imageFile}
         onClick={onClick}
-        stretchToFit={showBooleanLabel ? false : true}
+        stretchToFit={false}
         overflow={true}
       />
       {isBob ? (


### PR DESCRIPTION
I've noticed several minor bugs recently, and have fixed them in this PR:

- The timestamp for PV updates is always in BST, even when we are in GMT. This was noticed recently when attempting to plot Databrowser data. The latest data was always 1 hour ahead of the current time. This seems to be a quirk of how the time was being set.
- Theming was not applied to DynamicPage child screens. Previously the MUI theme was used by default, now the Phoebus theme or another custom theme (if passed in) is applied. This can be seen on the B23 pmacController screen in Daedalus
- Default display background colour now matches Phoebus default
- Text centering for Readback widgets