### PR TITLE
Add missing DType export

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,4 +5,5 @@ export type { Font } from "./font";
 export { FontStyle } from "./font";
 export { BorderStyle } from "./border";
 export type { Border } from "./border";
+export type { DType } from "./dtypes";
 export { resolveMacros } from "./macros";


### PR DESCRIPTION
Adds DType to the list of exported types, allowing it to be used in client applications.