### PR TITLE
Basic drag and drop display container  using react-grid-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",
@@ -16,6 +16,7 @@
         "loglevel": "^1.9.2",
         "plotly.js": "^3.4.0",
         "plotly.js-basic-dist": "^2.35.2",
+        "react-grid-layout": "^2.2.3",
         "react-plotly.js": "^2.6.0",
         "react-toastify": "^11.0.5",
         "utf-8-validate": "^5.0.10",
@@ -9205,6 +9206,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -13098,9 +13105,10 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -13234,6 +13242,20 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-gauge-component": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/react-gauge-component/-/react-gauge-component-2.0.26.tgz",
@@ -13246,6 +13268,24 @@
       "peerDependencies": {
         "react": "^16.8.2 || ^17.0 || ^18.x || ^19.x",
         "react-dom": "^16.8.2 || ^17.0 || ^18.x || ^19.x"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-id-generator": {
@@ -13314,6 +13354,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
+      "integrity": "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-router": {
@@ -13768,6 +13822,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {
@@ -27,6 +27,7 @@
     "loglevel": "^1.9.2",
     "plotly.js": "^3.4.0",
     "plotly.js-basic-dist": "^2.35.2",
+    "react-grid-layout": "^2.2.3",
     "react-plotly.js": "^2.6.0",
     "react-toastify": "^11.0.5",
     "utf-8-validate": "^5.0.10",
@@ -86,9 +87,9 @@
     "@types/react": "^18.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-gauge-component": "^2.0.26",
     "react-redux": "^7.2.9",
-    "react-router": "^7.13.0",
-    "react-gauge-component": "^2.0.26"
+    "react-router": "^7.13.0"
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/mui-material.d.ts
+++ b/src/mui-material.d.ts
@@ -37,6 +37,7 @@ declare module "@mui/material/styles" {
       selectedColor: string;
     };
     display: Palette["primary"];
+    displayResponsive: Palette["primary"];
     image: Palette["primary"];
     input: Palette["primary"];
     led: Palette["primary"] & {
@@ -74,6 +75,7 @@ declare module "@mui/material/styles" {
       selectedColor: string;
     };
     display?: PaletteOptions["primary"];
+    displayResponsive?: PaletteOptions["primary"];
     image?: PaletteOptions["primary"];
     input?: PaletteOptions["primary"];
     led?: Partial<PaletteOptions["primary"]> & {

--- a/src/phoebusTheme.ts
+++ b/src/phoebusTheme.ts
@@ -35,6 +35,10 @@ export const phoebusTheme = createTheme({
       main: "#ffffffff", // ensures a white background for the display
       contrastText: "#000000"
     },
+    displayResponsive: {
+      main: "#ffffffff", // ensures a white background for the display
+      contrastText: "#000000"
+    },
     image: {
       main: "rgba(255,255,255,0)",
       contrastText: "#000000"

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -54,6 +54,7 @@ const initialState: CsState = {
   deviceCache: {},
   fileCache: {
     "mySecondFile.bob": {
+      id: "123",
       type: "ellipse",
       position: newAbsolutePosition("0", "0", "0", "0")
     }
@@ -239,6 +240,7 @@ test("handles initializers", (): void => {
 describe("FILE_CHANGED", (): void => {
   test("csReducer adds file to fileCache", (): void => {
     const contents: WidgetDescription = {
+      id: "123",
       type: "shape",
       position: newAbsolutePosition("0", "0", "0", "0")
     };
@@ -380,10 +382,12 @@ describe("Selectors", () => {
   describe("fileComparator", (): void => {
     it("returns false if string contents don't match", (): void => {
       const contents1: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
       const contents2: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("1", "0", "0", "0")
       };
@@ -392,11 +396,13 @@ describe("Selectors", () => {
 
     it("returns false if number of keys changed", (): void => {
       const contents1: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0"),
         backgroundColor: ColorUtils.TRANSPARENT
       };
       const contents2: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -406,6 +412,7 @@ describe("Selectors", () => {
 
     it("returns true if matches", (): void => {
       const contents: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -416,6 +423,7 @@ describe("Selectors", () => {
   describe("selectFile", (): void => {
     it("finds file in fileCache", (): void => {
       const contents: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -9,12 +9,18 @@ import { Archiver, Trace } from "./trace";
 import { Axes, Axis } from "./axis";
 import { Points } from "./points";
 import { Plt } from "./plt";
+import {
+  ResponsiveBreakpoints,
+  ResponsiveColumns,
+  ResponsiveGridLayout
+} from "./responsiveBreakpoints";
 
 export type GenericProp =
   | string
   | string[]
   | boolean
   | number
+  | [number, number]
   | PV
   | { pvName: PV }[]
   | Color
@@ -31,7 +37,10 @@ export type GenericProp =
   | Axis
   | Points
   | Archiver
-  | Plt;
+  | Plt
+  | ResponsiveBreakpoints
+  | ResponsiveColumns
+  | ResponsiveGridLayout;
 
 export interface Expression {
   boolExp: string;

--- a/src/types/responsiveBreakpoints.ts
+++ b/src/types/responsiveBreakpoints.ts
@@ -1,0 +1,20 @@
+export type ResponsiveBreakpoints = Record<string, number>;
+export type ResponsiveColumns = Record<string, number>;
+
+export interface ResponsiveLayoutItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  minW?: number;
+  minH?: number;
+  maxW?: number;
+  maxH?: number;
+  static?: boolean;
+  isDraggable?: boolean;
+  isResizable?: boolean;
+}
+
+export type ResponsiveLayout = ResponsiveLayoutItem[];
+export type ResponsiveGridLayout = Record<string, ResponsiveLayout>;

--- a/src/ui/hooks/useFile.test.tsx
+++ b/src/ui/hooks/useFile.test.tsx
@@ -53,6 +53,7 @@ describe("useFile", (): void => {
 
     const responseContent = JSON.stringify({
       type: "shape",
+      id: "123",
       position: newAbsolutePosition("0", "0", "0", "0")
     });
 
@@ -61,6 +62,7 @@ describe("useFile", (): void => {
 
   it("returns contents if file in cache", async (): Promise<void> => {
     const mockSuccessResponse = JSON.stringify({
+      id: "1234",
       type: "ellipse",
       backgroundColor: ColorUtils.GREEN,
       position: undefined
@@ -98,6 +100,7 @@ describe("useFile", (): void => {
         positionType: PositionType.RELATIVE
       },
       backgroundColor: { colorString: "rgba(0,128,0,1)" },
+      id: "1234",
       children: [],
       precisionFromPv: true,
       showUnits: true,

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -18,6 +18,7 @@ import { newAbsolutePosition } from "../../types/position";
 
 const EMPTY_WIDGET: WidgetDescription = {
   type: "shape",
+  id: "123",
   position: newAbsolutePosition("0", "0", "0", "0")
 };
 
@@ -76,7 +77,6 @@ export function useFile(file: File, macros?: MacroMap): WidgetDescription {
   );
 
   useEffect(() => {
-    let isMounted = true;
     const fetchData = async (): Promise<void> => {
       const widgetDescription = await fetchAndConvert(
         file.path,
@@ -89,7 +89,11 @@ export function useFile(file: File, macros?: MacroMap): WidgetDescription {
         dispatch(fileChanged({ file: file.path, contents: widgetDescription }));
       }
     };
-    fetchData();
+
+    if (contents == null) {
+      fetchData();
+    }
+    let isMounted = true;
 
     // Tidy up in case component is unmounted
     return () => {

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -63,6 +63,7 @@ export const DeviceComponent = (
       }
       setComponent(
         widgetDescriptionToComponent({
+          id: "123",
           position: newRelativePosition("100%", "100%"),
           type: "display",
           children: [componentDescription]

--- a/src/ui/widgets/Device/deviceParser.ts
+++ b/src/ui/widgets/Device/deviceParser.ts
@@ -51,6 +51,7 @@ export const wordSplitter = (word: string): string =>
 
 export function createLabel(value: string): WidgetDescription {
   return {
+    id: "123",
     type: "label",
     position: "relative",
     text: `${wordSplitter(value)}`,
@@ -62,6 +63,7 @@ export function createLabel(value: string): WidgetDescription {
 
 export function createReadback(pv: string): WidgetDescription {
   return {
+    id: "123",
     type: "readback",
     position: "relative",
     width: "45%",
@@ -72,6 +74,7 @@ export function createReadback(pv: string): WidgetDescription {
 
 export function createInput(pv: string): WidgetDescription {
   return {
+    id: "123",
     type: "input",
     position: "relative",
     width: "45%",
@@ -85,6 +88,7 @@ export function createButton(
   description?: string
 ): WidgetDescription {
   return {
+    id: "123",
     type: "actionbutton",
     position: "relative",
     width: "45%",

--- a/src/ui/widgets/DisplayResponsive/displayResponsive.test.tsx
+++ b/src/ui/widgets/DisplayResponsive/displayResponsive.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { DisplayResponsiveComponent } from "./displayResponsive";
+
+vi.mock("react-grid-layout", async () => {
+  const actual = await vi.importActual<any>("react-grid-layout");
+
+  return {
+    ...actual,
+
+    Responsive: ({ children }: any) => (
+      <div data-testid="rgl-responsive">{children}</div>
+    ),
+
+    useContainerWidth: () => ({
+      width: 1200,
+      mounted: true,
+      containerRef: { current: null }
+    })
+  };
+});
+
+const MockWidget = ({ id }: { id: string }) => (
+  <div data-testid={`widget-${id}`}>Widget {id}</div>
+);
+
+describe("DisplayResponsiveComponent", () => {
+  it("renders the responsive container", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    const container = document.querySelector(".display-responsive-container");
+
+    expect(container).toBeTruthy();
+  });
+
+  it("renders the Responsive grid when mounted", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("rgl-responsive")).toBeInTheDocument();
+  });
+
+  it("renders child widgets", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+        <MockWidget id="b" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("widget-a")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-b")).toBeInTheDocument();
+  });
+
+  it("wraps each child in a grid item div", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+        <MockWidget id="b" />
+      </DisplayResponsiveComponent>
+    );
+
+    const grid = screen.getByTestId("rgl-responsive");
+
+    expect(grid.children.length).toBe(2);
+
+    expect(grid.children[0].firstElementChild).toHaveAttribute(
+      "data-testid",
+      "widget-a"
+    );
+
+    expect(grid.children[1].firstElementChild).toHaveAttribute(
+      "data-testid",
+      "widget-b"
+    );
+  });
+
+  it("accepts responsive configuration props", () => {
+    render(
+      <DisplayResponsiveComponent
+        id="display-1"
+        responsiveBreakpoints={{ lg: 1000, sm: 0 }}
+        responsiveColumns={{ lg: 10, sm: 4 }}
+        responsiveCellMargins={[8, 8]}
+        rowHeight="20"
+      >
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("widget-a")).toBeInTheDocument();
+  });
+});

--- a/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
@@ -1,0 +1,235 @@
+import React, { useState, useContext, ReactNode } from "react";
+import {
+  Layout,
+  ResponsiveLayouts,
+  Responsive,
+  useContainerWidth,
+  Breakpoints
+} from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+import { Widget } from "../widget";
+import { PVWidgetComponent, WidgetPropType } from "../widgetProps";
+import { registerWidget } from "../register";
+import {
+  ChoicePropOpt,
+  ChildrenPropOpt,
+  InferWidgetProps,
+  ColorPropOpt,
+  BorderPropOpt,
+  MacrosPropOpt,
+  StringPropOpt,
+  BoolPropOpt,
+  StringArrayPropOpt,
+  ObjectPropOpt,
+  IntArrayPropOpt,
+  IntPropOpt
+} from "../propTypes";
+import {
+  MacroMap,
+  MacroContext,
+  MacroContextType
+} from "../../../types/macros";
+import { useStyle } from "../../hooks/useStyle";
+
+const widgetName = "displayResponsive";
+
+// Default grid configuration
+const defaultBreakpoints = { lg: 1200, md: 600, sm: 0 }; // These are minimum widths in pixels
+const defaultCols = { lg: 32, md: 16, sm: 8 };
+const defaultRowHeight = 15;
+const defaultMArgins = [6, 6];
+
+const DisplayResponsiveProps = {
+  children: ChildrenPropOpt,
+  overflow: ChoicePropOpt(["scroll", "hidden", "auto", "visible"]),
+  backgroundColor: ColorPropOpt,
+  border: BorderPropOpt,
+  macros: MacrosPropOpt,
+  scaling: StringArrayPropOpt,
+  autoZoomToFit: BoolPropOpt,
+  scalingOrigin: StringPropOpt,
+  // New props for Responsive react-grid-layout
+  responsiveLayouts: ObjectPropOpt,
+  responsiveBreakpoints: ObjectPropOpt,
+  responsiveColumns: ObjectPropOpt,
+  responsiveCellMargins: IntArrayPropOpt,
+  responsiveCellHeight: IntPropOpt,
+  rowHeight: StringPropOpt,
+  isDraggable: BoolPropOpt,
+  isResizable: BoolPropOpt
+};
+
+// Display widget that uses react-grid-layout to provide a responsive drag and drop container
+export const DisplayResponsiveComponent = (
+  props: InferWidgetProps<typeof DisplayResponsiveProps> & { id: string }
+): JSX.Element => {
+  // Macros specific to this display. Children of this component
+  // can set macros by using the updateMacro function on the
+  // context.
+  const { width, containerRef, mounted } = useContainerWidth();
+  const inheritedMacros: MacroMap = useContext(MacroContext).macros;
+  const [displayMacros, setDisplayMacros] = useState<MacroMap>(
+    props.macros ?? {}
+  );
+  const displayMacroContext: MacroContextType = {
+    updateMacro: (key: string, value: string): void => {
+      setDisplayMacros({ ...displayMacros, [key]: value });
+    },
+    macros: {
+      ...inheritedMacros, // lower priority
+      ...displayMacros, // higher priority
+      DID: props.id // highest priority
+    }
+  };
+
+  // Get base style from common CSS
+  const style = useStyle(props, widgetName);
+  const extendedStyle: React.CSSProperties = {
+    ...style.colors,
+    ...style.border,
+    ...style.other,
+    ...style.font,
+    position: "relative",
+    overflow: props.overflow,
+    height: "100%"
+  };
+
+  const cellMargins = (props.responsiveCellMargins ?? defaultMArgins) as [
+    number,
+    number
+  ];
+
+  const breakpoints = (props?.responsiveBreakpoints ??
+    defaultBreakpoints) as Breakpoints<string>;
+  const columns = (props.responsiveColumns ?? defaultCols) as Record<
+    string,
+    number
+  >;
+
+  const childrenArray = React.useMemo(
+    () =>
+      React.Children.toArray(props.children as ReactNode[]).filter(child =>
+        React.isValidElement<PVWidgetComponent>(child)
+      ),
+    [props.children]
+  );
+
+  const layouts = React.useMemo(
+    () =>
+      props?.responsiveLayouts ??
+      calculateDefaultLayouts(childrenArray, cellMargins),
+    [props.responsiveLayouts, childrenArray, cellMargins]
+  );
+
+  // Wrap the child components in a div keyed by the child id. The key MUST map to the i field of Layout item for the component.
+  const gridChildren = React.useMemo(
+    () =>
+      childrenArray.map(child => {
+        const id = child.props.id;
+        if (!id) {
+          throw new Error("All grid items must have a stable id");
+        }
+
+        return <div key={id}>{child}</div>;
+      }),
+    [childrenArray]
+  );
+
+  return (
+    <MacroContext.Provider value={displayMacroContext}>
+      <div
+        ref={containerRef as React.RefObject<HTMLDivElement>}
+        style={extendedStyle}
+        className="display-responsive-container"
+      >
+        {mounted && (
+          <Responsive
+            className="layout"
+            layouts={layouts}
+            breakpoints={breakpoints}
+            cols={columns}
+            rowHeight={Number(props.rowHeight ?? defaultRowHeight)}
+            margin={cellMargins}
+            width={width}
+            resizeConfig={{ enabled: false }}
+            style={{
+              ...style.colors,
+              ...style.font,
+              height: "100%"
+            }}
+          >
+            {gridChildren}
+          </Responsive>
+        )}
+      </div>
+    </MacroContext.Provider>
+  );
+};
+
+const DisplayResponsiveWidgetProps = {
+  ...DisplayResponsiveProps,
+  ...WidgetPropType
+};
+
+// This is a temporary function to calculate breakpoints if none are specified.
+// Note that width in columns and height should be defined by the parent not the child in RGL,
+// so this will need to change when we implement child resizing.
+const calculateDefaultLayouts = (
+  childrenArray: React.ReactElement<
+    PVWidgetComponent,
+    string | React.JSXElementConstructor<any>
+  >[],
+  cellMargins: [number, number]
+): ResponsiveLayouts => {
+  const gridMetadata = childrenArray.map(child => {
+    const width = child?.props?.position?.width
+      ? Math.ceil(
+          (Number(child?.props?.position?.width?.replace(/px$/, "")) +
+            cellMargins[0]) /
+            (40 + cellMargins[0])
+        )
+      : 1;
+    const height = child?.props?.position?.height
+      ? Math.ceil(
+          (Number(child?.props?.position?.height?.replace(/px$/, "")) +
+            cellMargins[1]) /
+            (defaultRowHeight + cellMargins[1])
+        )
+      : 1;
+    const id = child.props.id;
+
+    return { width, height, id };
+  });
+
+  return {
+    lg: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: (i % 3) * 4,
+      y: Math.floor(i / 3),
+      w: child?.width,
+      h: child?.height
+    })) as Layout,
+    md: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: (i % 2) * 5,
+      y: Math.floor(i / 2),
+      w: child?.width,
+      h: child?.height
+    })) as Layout,
+    sm: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: 0,
+      y: i,
+      w: child?.width,
+      h: child?.height
+    })) as Layout
+  };
+};
+
+export const DisplayResponsive = (
+  props: InferWidgetProps<typeof DisplayResponsiveWidgetProps>
+): JSX.Element => <Widget baseWidget={DisplayResponsiveComponent} {...props} />;
+
+registerWidget(DisplayResponsive, DisplayResponsiveWidgetProps, widgetName);

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { bobParseNumber, bobParseNumberMandatory } from "./baseBobParsers";
+
+const element = (_text: any) => ({ _text });
+
+describe("bobParseNumber", () => {
+  it("parses a valid integer string", () => {
+    const result = bobParseNumber(element("42"));
+    expect(result).toBe(42);
+  });
+
+  it("parses a valid float string", () => {
+    const result = bobParseNumber(element("3.14"));
+    expect(result).toBe(3.14);
+  });
+
+  it("returns NaN for non-numeric strings", () => {
+    const result = bobParseNumber(element("not-a-number"));
+    expect(result).toBeNaN();
+  });
+
+  it("returns NaN when _text is undefined", () => {
+    const result = bobParseNumber({} as any);
+    expect(result).toBeNaN();
+  });
+
+  it("returns undefined if accessing _text throws", () => {
+    const badElement = {
+      get _text() {
+        throw new Error("boom");
+      }
+    };
+
+    const result = bobParseNumber(badElement as any);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("bobParseNumberMandatory", () => {
+  it("parses a valid integer string", () => {
+    const result = bobParseNumberMandatory(element("100"));
+    expect(result).toBe(100);
+  });
+
+  it("parses a valid float string", () => {
+    const result = bobParseNumberMandatory(element("2.5"));
+    expect(result).toBe(2.5);
+  });
+
+  it("returns NaN for non-numeric strings (does NOT throw)", () => {
+    const result = bobParseNumberMandatory(element("invalid"));
+    expect(result).toBeNaN();
+  });
+
+  it("throws if accessing _text throws", () => {
+    const badElement = {
+      get _text() {
+        throw new Error("boom");
+      }
+    };
+
+    expect(() => bobParseNumberMandatory(badElement as any)).toThrowError(
+      "Could not parse number from value undefined."
+    );
+  });
+});

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.ts
@@ -1,0 +1,20 @@
+import { ElementCompact } from "xml-js";
+
+export function bobParseNumber(jsonProp: ElementCompact): number | undefined {
+  try {
+    return Number(jsonProp._text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function bobParseNumberMandatory(jsonProp: ElementCompact): number {
+  let rawValue: any;
+
+  try {
+    rawValue = jsonProp._text;
+    return Number(jsonProp._text);
+  } catch {
+    throw new Error(`Could not parse number from value ${rawValue}.`);
+  }
+}

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import log from "loglevel";
+import { opiParseString } from "../opiParser";
+import { bobParseNumber } from "./baseBobParsers";
+
+import {
+  bobParseStringNumberMap,
+  bobParseResponsiveBreakpoints,
+  bobParseResponsiveMargins,
+  bobParseResponsiveColumns,
+  bobParseResponsiveLayout
+} from "./responsiveLayoutBobParser";
+
+vi.mock("../opiParser", () => ({
+  opiParseString: vi.fn()
+}));
+
+vi.mock("./baseBobParsers", () => ({
+  bobParseNumber: vi.fn()
+}));
+
+vi.mock("loglevel", () => ({
+  default: {
+    error: vi.fn()
+  }
+}));
+
+const asElementCompact = (obj: any) => obj;
+
+describe("bobParseStringNumberMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps string keys to parsed numeric values", () => {
+    (bobParseNumber as any).mockReturnValueOnce(1200).mockReturnValueOnce(600);
+
+    const input = asElementCompact({
+      lg: "1200",
+      md: "600"
+    });
+
+    const result = bobParseStringNumberMap(input);
+
+    expect(result).toEqual({
+      lg: 1200,
+      md: 600
+    });
+
+    expect(bobParseNumber).toHaveBeenCalledTimes(2);
+  });
+
+  it("filters out null values", () => {
+    (bobParseNumber as any).mockReturnValueOnce(1200).mockReturnValueOnce(null);
+
+    const input = asElementCompact({
+      lg: "1200",
+      md: "invalid"
+    });
+
+    const result = bobParseStringNumberMap(input);
+
+    expect(result).toEqual({
+      lg: 1200
+    });
+  });
+});
+
+describe("bobParseResponsiveBreakpoints", () => {
+  it("delegates to bobParseStringNumberMap", () => {
+    (bobParseNumber as any).mockReturnValue(1000);
+
+    const result = bobParseResponsiveBreakpoints(
+      asElementCompact({ lg: "1000" })
+    );
+
+    expect(result).toEqual({ lg: 1000 });
+  });
+});
+
+describe("bobParseResponsiveColumns", () => {
+  it("delegates to bobParseStringNumberMap", () => {
+    (bobParseNumber as any).mockReturnValue(12);
+
+    const result = bobParseResponsiveColumns(asElementCompact({ lg: "12" }));
+
+    expect(result).toEqual({ lg: 12 });
+  });
+});
+
+describe("bobParseResponsiveMargins", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses two space-separated numbers", () => {
+    (opiParseString as any).mockReturnValue("10 20");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([10, 20]);
+  });
+
+  it("defaults missing second value", () => {
+    (opiParseString as any).mockReturnValue("8");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([8, 6]);
+  });
+
+  it("falls back to default margins on invalid numbers", () => {
+    (opiParseString as any).mockReturnValue("10 nope");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([6, 6]);
+    expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe("bobParseResponsiveLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses responsive layouts correctly", () => {
+    const input = asElementCompact({
+      lg: {
+        element_position: [
+          {
+            _attributes: {
+              i: "a",
+              x: "0",
+              y: "1",
+              w: "4",
+              h: "2"
+            }
+          }
+        ]
+      }
+    });
+
+    const result = bobParseResponsiveLayout(input);
+
+    expect(result).toEqual({
+      lg: [
+        {
+          i: "a",
+          x: 0,
+          y: 1,
+          w: 4,
+          h: 2
+        }
+      ]
+    });
+  });
+
+  it("returns empty arrays when no positions exist", () => {
+    const input = asElementCompact({
+      lg: {
+        element_position: []
+      }
+    });
+
+    const result = bobParseResponsiveLayout(input);
+
+    expect(result).toEqual({
+      lg: []
+    });
+  });
+
+  it("returns empty object if parsing throws", () => {
+    const badInput = null as any;
+
+    const result = bobParseResponsiveLayout(badInput);
+
+    expect(result).toEqual({});
+    expect(log.error).toHaveBeenCalled();
+  });
+});

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.ts
@@ -1,0 +1,86 @@
+import { ElementCompact } from "xml-js";
+import log from "loglevel";
+import {
+  ResponsiveBreakpoints,
+  ResponsiveColumns,
+  ResponsiveGridLayout,
+  ResponsiveLayout,
+  ResponsiveLayoutItem
+} from "../../../../types/responsiveBreakpoints";
+import { opiParseString } from "../opiParser";
+import { bobParseNumber } from "./baseBobParsers";
+
+export const bobParseStringNumberMap = (
+  jsonProp: ElementCompact
+): ResponsiveBreakpoints =>
+  Object.fromEntries(
+    Object.entries(jsonProp)
+      .map(([key, value]) => [key, bobParseNumber(value)])
+      .filter(x => x[1] != null)
+  );
+
+export const bobParseResponsiveBreakpoints = (
+  jsonProp: ElementCompact
+): ResponsiveBreakpoints => bobParseStringNumberMap(jsonProp);
+
+export const bobParseResponsiveMargins = (
+  jsonProp: ElementCompact
+): [number, number] => {
+  const spaceSeparatedArray = opiParseString(jsonProp);
+
+  const margins = spaceSeparatedArray?.trim()?.split(/\s+/)?.map(Number);
+
+  if (margins.some(v => !Number.isFinite(Number(v)))) {
+    log.error(
+      "Invalid number in space separated number array: ",
+      spaceSeparatedArray
+    );
+    return [6, 6];
+  }
+
+  return [margins[0] ?? 6, margins[1] ?? 6];
+};
+
+export const bobParseResponsiveColumns = (
+  jsonProp: ElementCompact
+): ResponsiveColumns => bobParseStringNumberMap(jsonProp);
+
+export const bobParseResponsiveLayout = (
+  jsonProp: ElementCompact
+): ResponsiveGridLayout => {
+  try {
+    return Object.fromEntries(
+      Object.entries(jsonProp)
+        .map(([key, value]) => [key, bobParseResponsiveComponentLayouts(value)])
+        .filter(x => x[1] != null)
+    );
+  } catch (error) {
+    log.error("bobParser: Failed to parse a responsive layout");
+    log.error(error);
+    return {};
+  }
+};
+
+const bobParseResponsiveComponentLayouts = (
+  jsonProp: ElementCompact
+): ResponsiveLayout => {
+  if (!jsonProp?.element_position || jsonProp?.element_position?.length === 0) {
+    return [];
+  }
+
+  return jsonProp.element_position
+    .filter((element: ElementCompact) => !!element?._attributes)
+    .map((element: ElementCompact) =>
+      bobParseResponsiveItem(element._attributes as ElementCompact)
+    );
+};
+
+const bobParseResponsiveItem = (
+  jsonProp: ElementCompact
+): ResponsiveLayoutItem => ({
+  i: jsonProp?.i,
+  x: Number(jsonProp?.x),
+  y: Number(jsonProp?.y),
+  w: Number(jsonProp?.w),
+  h: Number(jsonProp?.h)
+});

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -49,6 +49,13 @@ import { Trace } from "../../../types/trace";
 import { parsePlt } from "./pltParser";
 import { scriptParser } from "./scripts/scriptParser";
 import { MacroMap } from "../../../types/macros";
+import { bobParseNumber } from "./BobParsers/baseBobParsers";
+import {
+  bobParseResponsiveBreakpoints,
+  bobParseResponsiveColumns,
+  bobParseResponsiveLayout,
+  bobParseResponsiveMargins
+} from "./BobParsers/responsiveLayoutBobParser";
 
 const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   action_button: "actionbutton",
@@ -59,6 +66,7 @@ const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   combo: "menubutton",
   databrowser: "databrowser",
   display: "display",
+  displayResponsive: "displayResponsive",
   ellipse: "ellipse",
   embedded: "embeddedDisplay",
   group: "groupbox",
@@ -96,6 +104,7 @@ export const WIDGET_DEFAULT_SIZES: { [key: string]: [number, number] } = {
   combo: [100, 30],
   databrowser: [400, 300],
   display: [800, 800],
+  displayResponsive: [800, 800],
   ellipse: [100, 50],
   embedded: [400, 300],
   group: [300, 200],
@@ -126,14 +135,6 @@ function bobParseType(props: any): string {
     return BOB_WIDGET_MAPPING[typeId];
   } else {
     return typeId;
-  }
-}
-
-export function bobParseNumber(jsonProp: ElementCompact): number | undefined {
-  try {
-    return Number(jsonProp._text);
-  } catch {
-    return undefined;
   }
 }
 
@@ -494,6 +495,7 @@ function bobGetTargetWidget(props: any): {
 
 export const BOB_SIMPLE_PARSERS: ParserDict = {
   ...OPI_SIMPLE_PARSERS,
+  id: ["id", opiParseString],
   font: ["font", bobParseFont],
   items: ["items", bobParseItems],
   imageFile: ["file", opiParseString],
@@ -555,6 +557,14 @@ export const BOB_SIMPLE_PARSERS: ParserDict = {
   end: ["end", opiParseString],
   arrayIndex: ["array_index", bobParseNumber],
   direction: ["direction", bobParseNumber],
+  responsiveLayouts: ["responsive_layouts", bobParseResponsiveLayout],
+  responsiveBreakpoints: [
+    "responsive_breakpoints",
+    bobParseResponsiveBreakpoints
+  ],
+  responsiveColumns: ["responsive_columns", bobParseResponsiveColumns],
+  responsiveCellMargins: ["responsive_cell_margins", bobParseResponsiveMargins],
+  responsiveCellHeight: ["responsive_cell_height", bobParseNumber],
   tabWidth: ["tab_width", bobParseNumber],
   tabHeight: ["tab_height", bobParseNumber],
   tabSpacing: ["tab_spacing", bobParseNumber],
@@ -581,7 +591,18 @@ export async function parseBob(
   const compactJSON = xml2js(xmlString, {
     compact: true
   }) as XmlDescription;
-  compactJSON.display._attributes.type = "display";
+  const display = compactJSON?.display ?? compactJSON?.displayResponsive;
+  const displayAttributes = {
+    ...display,
+    _attributes: {
+      ...display._attributes,
+      type: compactJSON?.display ? "display" : "displayResponsive"
+    },
+    x: { _text: "0" },
+    y: { _text: "0" }
+  };
+
+  compactJSON["display"] = displayAttributes;
   log.debug(compactJSON);
 
   const simpleParsers: ParserDict = {

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
@@ -270,7 +270,10 @@ describe("<EmbeddedDisplay>", (): void => {
 
     const display = container.querySelector(".display");
     expect(display).not.toBeNull();
-    const innerDisplayWidgetWrapper = display?.firstElementChild;
+
+    const innerDisplayWidgetWrapper =
+      display?.firstElementChild?.firstElementChild;
+
     expect(innerDisplayWidgetWrapper).toHaveStyle("position: absolute");
 
     // This should match the size of the selected group
@@ -282,7 +285,7 @@ describe("<EmbeddedDisplay>", (): void => {
 
     const displayInner = display?.querySelector(".display");
     expect(displayInner).not.toBeNull();
-    const groupBoxWidgetWrapper = displayInner?.firstChild;
+    const groupBoxWidgetWrapper = displayInner?.firstChild?.firstChild;
     expect(groupBoxWidgetWrapper).toHaveStyle("position: absolute");
     expect(groupBoxWidgetWrapper).toHaveStyle("height: 250px");
     expect(groupBoxWidgetWrapper).toHaveStyle("width: 240px");

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -62,7 +62,7 @@ export const EmbeddedDisplay = (
   props: InferWidgetProps<typeof EmbeddedDisplayProps> &
     EmbeddedDisplayPropsExtra
 ): JSX.Element => {
-  const id = useId();
+  const [id] = useId();
 
   // First resolve the macros
   // Include and override parent macros with those from the prop.
@@ -251,6 +251,7 @@ export const EmbeddedDisplay = (
   try {
     component = widgetDescriptionToComponent({
       type: "display",
+      id: `display_${crypto.randomUUID()}`,
       position: resolvedProps.position,
       backgroundColor:
         selectedDescription.backgroundColor ?? newColor("rgb(255,255,255"),

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -1001,7 +1001,7 @@ export async function parseOpi(
   };
 
   const displayWidget = await parseWidget(
-    compactJSON.display,
+    compactJSON?.display ?? compactJSON?.displayResponsive,
     opiGetTargetWidget,
     "widget",
     simpleParsers,

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -129,6 +129,11 @@ export async function genericParser(
     }));
   }
 
+  // attach an id if it does not exist
+  if (!newProps?.id) {
+    newProps["id"] = `${newProps.type}_${crypto.randomUUID()}`;
+  }
+
   return newProps;
 }
 

--- a/src/ui/widgets/Tabs/tabContainer.tsx
+++ b/src/ui/widgets/Tabs/tabContainer.tsx
@@ -58,6 +58,7 @@ export const TabContainerComponent = (
           name: tab.name,
           children: widgetDescriptionToComponent({
             type: "display",
+            id: "123",
             position: newRelativePosition(
               "0px",
               `${tabHeight}px`,

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -10,12 +10,14 @@ import { BorderStyle, newBorder } from "../../types/border";
 
 export interface WidgetDescription {
   type: string;
+  id: string;
   // All other component properties
   [x: string]: any;
   children?: WidgetDescription[];
 }
 const ERROR_WIDGET: WidgetDescription = {
   type: "label",
+  id: `label_${crypto.randomUUID()}`,
   position: newRelativePosition(),
   font: newFont(16, FontStyle.Bold),
   backgroundColor: ColorUtils.TRANSPARENT,

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -3,6 +3,7 @@ import log from "loglevel";
 export { EmbeddedDisplay } from "./EmbeddedDisplay/embeddedDisplay";
 export { Label } from "./Label/label";
 export { Display } from "./Display/display";
+export { DisplayResponsive } from "./DisplayResponsive/displayResponsive";
 export { Shape } from "./Shape/shape";
 export { FlexContainer } from "./FlexContainer/flexContainer";
 export { DynamicPageWidget } from "./DynamicPage/dynamicPage";

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -21,6 +21,8 @@ export const StringArrayPropOpt = PropTypes.arrayOf(PropTypes.string);
 export const IntProp = PropTypes.number.isRequired;
 export const IntPropOpt = PropTypes.number;
 
+export const IntArrayPropOpt = PropTypes.arrayOf(PropTypes.number.isRequired);
+
 export const FloatProp = PropTypes.number.isRequired;
 export const FloatPropOpt = PropTypes.number;
 

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -327,7 +327,7 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
   };
 
   return (
-    <>
+    <div id={`WidgetContainer_${props?.id ?? id}`}>
       {actionsPresent && contextOpen && (
         <ContextMenu
           actions={ruleProps.actions as WidgetActions}
@@ -341,6 +341,6 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
       />
-    </>
+    </div>
   );
 };

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -18,6 +18,7 @@ import { File } from "../hooks/useFile";
 
 // Internal prop types object for properties which are not in a standard widget
 const BasicPropsType = {
+  id: StringPropOpt,
   rules: RulesPropOpt,
   scripts: ScriptsPropOpt,
   actions: ActionsPropType,


### PR DESCRIPTION
This PR:
- adds the DisplayResponsive widget, which is a container widget that uses react-grid-view to provide a drag and drop capability for the immediate child widgets.
-  attempts to set the column width span of the child items using the width of the child item. This is works against the paradigm of RGL, we will need to fix this later. 
- adds an extension to the bob file format in order to support the new DisplayResponsive widget, this includes a means of defining the child widget layout within the DisplayResponsive container.
- gives all widgets an id that can be used as a key to identify widgets by RGL.