### PR TITLE
React grid layout responsive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",
@@ -16,6 +16,7 @@
         "loglevel": "^1.9.2",
         "plotly.js": "^3.4.0",
         "plotly.js-basic-dist": "^2.35.2",
+        "react-grid-layout": "^2.2.3",
         "react-plotly.js": "^2.6.0",
         "react-toastify": "^11.0.5",
         "utf-8-validate": "^5.0.10",
@@ -9205,6 +9206,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -13098,9 +13105,10 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -13234,6 +13242,20 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-gauge-component": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/react-gauge-component/-/react-gauge-component-2.0.26.tgz",
@@ -13246,6 +13268,24 @@
       "peerDependencies": {
         "react": "^16.8.2 || ^17.0 || ^18.x || ^19.x",
         "react-dom": "^16.8.2 || ^17.0 || ^18.x || ^19.x"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-id-generator": {
@@ -13314,6 +13354,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
+      "integrity": "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-router": {
@@ -13768,6 +13822,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {
@@ -27,6 +27,7 @@
     "loglevel": "^1.9.2",
     "plotly.js": "^3.4.0",
     "plotly.js-basic-dist": "^2.35.2",
+    "react-grid-layout": "^2.2.3",
     "react-plotly.js": "^2.6.0",
     "react-toastify": "^11.0.5",
     "utf-8-validate": "^5.0.10",
@@ -86,9 +87,9 @@
     "@types/react": "^18.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-gauge-component": "^2.0.26",
     "react-redux": "^7.2.9",
-    "react-router": "^7.13.0",
-    "react-gauge-component": "^2.0.26"
+    "react-router": "^7.13.0"
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/connection/pvws/pvwsToDType.ts
+++ b/src/connection/pvws/pvwsToDType.ts
@@ -37,7 +37,7 @@ export const pvwsToDType = (data: any): DType => {
   ddisplay = newDDisplay({
     description: undefined,
     role: undefined,
-    controlRange: undefined,
+    controlRange: data.min != null ? newDRange(data.min, data.max) : undefined,
     alarmRange:
       data.alarm_low != null
         ? newDRange(data.alarm_low, data.alarm_high)

--- a/src/mui-material.d.ts
+++ b/src/mui-material.d.ts
@@ -37,6 +37,7 @@ declare module "@mui/material/styles" {
       selectedColor: string;
     };
     display: Palette["primary"];
+    displayResponsive: Palette["primary"];
     image: Palette["primary"];
     input: Palette["primary"];
     led: Palette["primary"] & {
@@ -74,6 +75,7 @@ declare module "@mui/material/styles" {
       selectedColor: string;
     };
     display?: PaletteOptions["primary"];
+    displayResponsive?: PaletteOptions["primary"];
     image?: PaletteOptions["primary"];
     input?: PaletteOptions["primary"];
     led?: Partial<PaletteOptions["primary"]> & {

--- a/src/phoebusTheme.ts
+++ b/src/phoebusTheme.ts
@@ -35,6 +35,10 @@ export const phoebusTheme = createTheme({
       main: "#ffffffff", // ensures a white background for the display
       contrastText: "#000000"
     },
+    displayResponsive: {
+      main: "#ffffffff", // ensures a white background for the display
+      contrastText: "#000000"
+    },
     image: {
       main: "rgba(255,255,255,0)",
       contrastText: "#000000"

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -54,6 +54,7 @@ const initialState: CsState = {
   deviceCache: {},
   fileCache: {
     "mySecondFile.bob": {
+      id: "123",
       type: "ellipse",
       position: newAbsolutePosition("0", "0", "0", "0")
     }
@@ -239,6 +240,7 @@ test("handles initializers", (): void => {
 describe("FILE_CHANGED", (): void => {
   test("csReducer adds file to fileCache", (): void => {
     const contents: WidgetDescription = {
+      id: "123",
       type: "shape",
       position: newAbsolutePosition("0", "0", "0", "0")
     };
@@ -380,10 +382,12 @@ describe("Selectors", () => {
   describe("fileComparator", (): void => {
     it("returns false if string contents don't match", (): void => {
       const contents1: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
       const contents2: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("1", "0", "0", "0")
       };
@@ -392,11 +396,13 @@ describe("Selectors", () => {
 
     it("returns false if number of keys changed", (): void => {
       const contents1: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0"),
         backgroundColor: ColorUtils.TRANSPARENT
       };
       const contents2: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -406,6 +412,7 @@ describe("Selectors", () => {
 
     it("returns true if matches", (): void => {
       const contents: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -416,6 +423,7 @@ describe("Selectors", () => {
   describe("selectFile", (): void => {
     it("finds file in fileCache", (): void => {
       const contents: WidgetDescription = {
+        id: "123",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -9,12 +9,18 @@ import { Archiver, Trace } from "./trace";
 import { Axes, Axis } from "./axis";
 import { Points } from "./points";
 import { Plt } from "./plt";
+import {
+  ResponsiveBreakpoints,
+  ResponsiveColumns,
+  ResponsiveGridLayout
+} from "./responsiveBreakpoints";
 
 export type GenericProp =
   | string
   | string[]
   | boolean
   | number
+  | [number, number]
   | PV
   | { pvName: PV }[]
   | Color
@@ -31,7 +37,10 @@ export type GenericProp =
   | Axis
   | Points
   | Archiver
-  | Plt;
+  | Plt
+  | ResponsiveBreakpoints
+  | ResponsiveColumns
+  | ResponsiveGridLayout;
 
 export interface Expression {
   boolExp: string;

--- a/src/types/responsiveBreakpoints.ts
+++ b/src/types/responsiveBreakpoints.ts
@@ -1,0 +1,20 @@
+export type ResponsiveBreakpoints = Record<string, number>;
+export type ResponsiveColumns = Record<string, number>;
+
+export interface ResponsiveLayoutItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  minW?: number;
+  minH?: number;
+  maxW?: number;
+  maxH?: number;
+  static?: boolean;
+  isDraggable?: boolean;
+  isResizable?: boolean;
+}
+
+export type ResponsiveLayout = ResponsiveLayoutItem[];
+export type ResponsiveGridLayout = Record<string, ResponsiveLayout>;

--- a/src/ui/hooks/useFile.test.tsx
+++ b/src/ui/hooks/useFile.test.tsx
@@ -53,6 +53,7 @@ describe("useFile", (): void => {
 
     const responseContent = JSON.stringify({
       type: "shape",
+      id: "123",
       position: newAbsolutePosition("0", "0", "0", "0")
     });
 
@@ -61,6 +62,7 @@ describe("useFile", (): void => {
 
   it("returns contents if file in cache", async (): Promise<void> => {
     const mockSuccessResponse = JSON.stringify({
+      id: "1234",
       type: "ellipse",
       backgroundColor: ColorUtils.GREEN,
       position: undefined
@@ -98,6 +100,7 @@ describe("useFile", (): void => {
         positionType: PositionType.RELATIVE
       },
       backgroundColor: { colorString: "rgba(0,128,0,1)" },
+      id: "1234",
       children: [],
       precisionFromPv: true,
       showUnits: true,

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -18,6 +18,7 @@ import { newAbsolutePosition } from "../../types/position";
 
 const EMPTY_WIDGET: WidgetDescription = {
   type: "shape",
+  id: "123",
   position: newAbsolutePosition("0", "0", "0", "0")
 };
 
@@ -76,7 +77,6 @@ export function useFile(file: File, macros?: MacroMap): WidgetDescription {
   );
 
   useEffect(() => {
-    let isMounted = true;
     const fetchData = async (): Promise<void> => {
       const widgetDescription = await fetchAndConvert(
         file.path,
@@ -89,7 +89,11 @@ export function useFile(file: File, macros?: MacroMap): WidgetDescription {
         dispatch(fileChanged({ file: file.path, contents: widgetDescription }));
       }
     };
-    fetchData();
+
+    if (contents == null) {
+      fetchData();
+    }
+    let isMounted = true;
 
     // Tidy up in case component is unmounted
     return () => {

--- a/src/ui/hooks/useMeasuredSize.test.tsx
+++ b/src/ui/hooks/useMeasuredSize.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { useMeasuredSize } from "./useMeasuredSize";
+
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+
+class MockResizeObserver {
+  static callback: ResizeCallback | null = null;
+  static instance: MockResizeObserver;
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(cb: ResizeCallback) {
+    MockResizeObserver.callback = cb;
+    MockResizeObserver.instance = this;
+  }
+}
+
+(global as any).ResizeObserver = MockResizeObserver;
+
+const TestComponent = ({
+  initialWidth = 0,
+  initialHeight = 0
+}: {
+  initialWidth?: number;
+  initialHeight?: number;
+}) => {
+  const [ref, size] = useMeasuredSize<HTMLDivElement>(
+    initialWidth,
+    initialHeight
+  );
+
+  return (
+    <div ref={ref} data-testid="container">
+      <span data-testid="width">{size.width}</span>
+      <span data-testid="height">{size.height}</span>
+    </div>
+  );
+};
+
+describe("useMeasuredSize", () => {
+  beforeEach(() => {
+    MockResizeObserver.callback = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("returns the initial width and height", () => {
+    render(<TestComponent initialWidth={100} initialHeight={50} />);
+
+    expect(screen.getByTestId("width").textContent).toBe("100");
+    expect(screen.getByTestId("height").textContent).toBe("50");
+  });
+
+  it("updates size when ResizeObserver reports valid dimensions", () => {
+    render(<TestComponent />);
+
+    act(() => {
+      MockResizeObserver.callback?.([
+        {
+          contentRect: { width: 200, height: 120 }
+        } as ResizeObserverEntry
+      ]);
+    });
+
+    expect(screen.getByTestId("width").textContent).toBe("200");
+    expect(screen.getByTestId("height").textContent).toBe("120");
+  });
+
+  it("ignores zero or negative sizes", () => {
+    render(<TestComponent initialWidth={100} initialHeight={50} />);
+
+    act(() => {
+      MockResizeObserver.callback?.([
+        {
+          contentRect: { width: 0, height: 0 }
+        } as ResizeObserverEntry
+      ]);
+    });
+
+    expect(screen.getByTestId("width").textContent).toBe("100");
+    expect(screen.getByTestId("height").textContent).toBe("50");
+  });
+
+  it("ignores changes smaller than 1px", () => {
+    render(<TestComponent initialWidth={100} initialHeight={50} />);
+
+    act(() => {
+      MockResizeObserver.callback?.([
+        {
+          contentRect: { width: 100.4, height: 50.6 }
+        } as ResizeObserverEntry
+      ]);
+    });
+
+    expect(screen.getByTestId("width").textContent).toBe("100");
+    expect(screen.getByTestId("height").textContent).toBe("50");
+  });
+
+  it("updates when width or height changes by 1px or more", () => {
+    render(<TestComponent initialWidth={100} initialHeight={50} />);
+
+    act(() => {
+      MockResizeObserver.callback?.([
+        {
+          contentRect: { width: 101, height: 52 }
+        } as ResizeObserverEntry
+      ]);
+    });
+
+    expect(screen.getByTestId("width").textContent).toBe("101");
+    expect(screen.getByTestId("height").textContent).toBe("52");
+  });
+
+  it("disconnects the ResizeObserver on unmount", () => {
+    const { unmount } = render(<TestComponent />);
+    unmount();
+    expect(MockResizeObserver.instance?.disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/ui/hooks/useMeasuredSize.tsx
+++ b/src/ui/hooks/useMeasuredSize.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * This hook is used to return the size of the component attached to the returned ref,
+ * which is useful if you need to compute the dimensions of a resizable element.
+ * @param initialWidth The initial width in pixels.
+ * @param initialHeight The initial height in pixels
+ * @returns A reference to be attached to a component and a size object { width, height }
+ */
+export const useMeasuredSize = <T extends Element>(
+  initialWidth = 0,
+  initialHeight = 0
+): [React.MutableRefObject<T | null>, { width: number; height: number }] => {
+  const ref = useRef<T | null>(null);
+  const [size, setSize] = useState({
+    width: initialWidth,
+    height: initialHeight
+  });
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    let lastWidth = initialWidth;
+    let lastHeight = initialHeight;
+
+    const observer = new ResizeObserver(entries => {
+      const { width, height } = entries[0].contentRect;
+
+      if (width <= 0 || height <= 0) return;
+
+      if (
+        Math.abs(width - lastWidth) < 1 &&
+        Math.abs(height - lastHeight) < 1
+      ) {
+        return;
+      }
+
+      lastWidth = width;
+      lastHeight = height;
+
+      setSize({ width, height });
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [initialWidth, initialHeight]);
+
+  return [ref, size];
+};

--- a/src/ui/widgets/Arc/arc.tsx
+++ b/src/ui/widgets/Arc/arc.tsx
@@ -7,18 +7,21 @@ import {
   InferWidgetProps,
   ColorPropOpt,
   IntPropOpt,
-  MacrosPropOpt
+  MacrosPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import classes from "./arc.module.css";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 import { useStyle } from "../../hooks/useStyle";
 import { calculateArc } from "./arcUtils";
+import { parseToPixelInt } from "../utils";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const widgetName = "arc";
 
 const ArcProps = {
   macros: MacrosPropOpt,
-  width: IntPropOpt,
+  width: StringPropOpt,
   height: IntPropOpt,
   backgroundColor: ColorPropOpt,
   foregroundColor: ColorPropOpt,
@@ -54,13 +57,20 @@ export const ArcComponent = (
     totalAngle = 90,
     lineWidth = 3
   } = props;
+
+  const [ref, size] = useMeasuredSize<SVGSVGElement>(
+    parseToPixelInt(width, WIDGET_DEFAULT_SIZES["arc"][0]),
+    height
+  );
+
   const [arc, edge] = calculateArc(
-    width,
-    height,
+    size.width,
+    size.height,
     startAngle,
     totalAngle,
     lineWidth
   );
+
   // Combine edge if not full circle or filled
   const shape = transparent || totalAngle === 360 ? arc : arc.concat(edge);
 
@@ -76,7 +86,13 @@ export const ArcComponent = (
   );
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} overflow={"visible"}>
+    <svg
+      ref={ref}
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${size.width} ${size.height}`}
+      overflow={"visible"}
+    >
       {element}
     </svg>
   );

--- a/src/ui/widgets/BoolButton/boolButton.test.tsx
+++ b/src/ui/widgets/BoolButton/boolButton.test.tsx
@@ -28,6 +28,13 @@ vi.mock("../../hooks/useStyle", () => ({
   )
 }));
 
+vi.mock("../../hooks/useMeasuredSize", () => ({
+  useMeasuredSize: (width: number, height: number) => [
+    { current: null },
+    { width, height }
+  ]
+}));
+
 beforeEach((): void => {
   mockWritePv.mockReset();
 });
@@ -67,7 +74,7 @@ describe("<BoolButton />", (): void => {
     const { getByRole } = render(BoolButtonRenderer(boolButtonProps));
     const button = getByRole("button") as HTMLButtonElement;
     const spanElement = button.firstChild as HTMLSpanElement;
-    const led = spanElement.children[0] as HTMLSpanElement;
+    const led = spanElement.children[0].children[0] as HTMLSpanElement;
 
     expect(button).toHaveStyle({
       "background-color": "rgba(0, 0, 0, 1)",
@@ -77,7 +84,7 @@ describe("<BoolButton />", (): void => {
     });
 
     expect(led.style.backgroundColor).toEqual("rgb(0, 235, 10)");
-    expect(led.style.height).toEqual("16px");
+    expect(led.style.height).toEqual("100%");
   });
 
   test("it renders a button with led and overwrites default values", (): void => {
@@ -88,12 +95,12 @@ describe("<BoolButton />", (): void => {
     const { getByRole } = render(BoolButtonRenderer(boolButtonProps));
     const button = getByRole("button") as HTMLButtonElement;
     const spanElement = button.firstChild as HTMLSpanElement;
-    const led = spanElement.children[0] as HTMLSpanElement;
+    const led = spanElement.children[0].children[0] as HTMLSpanElement;
 
     expect(button.textContent).toEqual("Enabled");
     expect(led.className).toContain("Led");
     expect(led.style.backgroundColor).toEqual("rgb(0, 235, 10)");
-    expect(led.style.height).toEqual("11px");
+    expect(led.style.height).toEqual("100%");
 
     expect(button).toHaveStyle({
       "background-color": "rgba(0, 0, 0, 1)",
@@ -137,7 +144,7 @@ describe("<BoolButton />", (): void => {
     const { getByRole } = render(BoolButtonRenderer(boolButtonProps));
     const button = getByRole("button") as HTMLButtonElement;
     const spanElement = button.firstChild as HTMLSpanElement;
-    const led = spanElement.children[0] as HTMLSpanElement;
+    const led = spanElement.children[0].children[0] as HTMLSpanElement;
     // Original on values
     expect(button.textContent).toEqual("Enabled");
     expect(led.style.backgroundColor).toEqual("rgb(0, 235, 10)");

--- a/src/ui/widgets/BoolButton/boolButton.tsx
+++ b/src/ui/widgets/BoolButton/boolButton.tsx
@@ -17,16 +17,17 @@ import { writePv } from "../../hooks/useSubscription";
 import { dTypeGetDoubleValue, newDType } from "../../../types/dtypes";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 import { Button as MuiButton, styled } from "@mui/material";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseToPixelInt } from "../utils";
 import { LedComponent } from "../LED/led";
 import { useStyle } from "../../hooks/useStyle";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const widgetName = "boolbutton";
 
 const BoolButtonProps = {
   pvName: StringPropOpt,
   height: IntPropOpt,
-  width: IntPropOpt,
+  width: StringPropOpt,
   onState: IntPropOpt,
   offState: IntPropOpt,
   onColor: ColorPropOpt,
@@ -112,6 +113,13 @@ export const BoolButtonComponent = (
     readOnly
   } = getPvValueAndName(pvData);
 
+  const pixelWidth = parseToPixelInt(
+    width,
+    WIDGET_DEFAULT_SIZES["bool_button"][0]
+  );
+
+  const [ref, size] = useMeasuredSize<HTMLDivElement>(pixelWidth, height);
+
   // These could be overwritten by  PV labels
   let { onLabel = "On", offLabel = "Off" } = props;
 
@@ -131,7 +139,7 @@ export const BoolButtonComponent = (
   const [ledColor, setLedColor] = useState(style?.customColors?.offColor);
 
   // Establish LED style
-  const ledDiameter = showLed ? getDimensions(width, height) : 0;
+  const ledDiameter = showLed ? getDimensions(size.width, size.height) : 0;
 
   // This is necessary in order to set the initial label value
   // after connection to PV established, as setState cannot be
@@ -169,7 +177,7 @@ export const BoolButtonComponent = (
   }
 
   return (
-    <>
+    <div ref={ref} style={{ width: "100%", height: "100%" }}>
       <Button
         variant="contained"
         onClick={handleClick}
@@ -192,13 +200,13 @@ export const BoolButtonComponent = (
         }}
         startIcon={
           showLed ? (
-            <LedComponent
-              pvData={pvData}
-              onColor={newColor(style?.customColors?.onColor)}
-              offColor={newColor(style?.customColors?.offColor)}
-              width={ledDiameter}
-              height={ledDiameter}
-            />
+            <div style={{ width: `${ledDiameter}`, height: ledDiameter }}>
+              <LedComponent
+                pvData={pvData}
+                onColor={newColor(style?.customColors?.onColor)}
+                offColor={newColor(style?.customColors?.offColor)}
+              />
+            </div>
           ) : (
             <></>
           )
@@ -206,7 +214,7 @@ export const BoolButtonComponent = (
       >
         {label}
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/src/ui/widgets/ByteMonitor/byteMonitor.tsx
+++ b/src/ui/widgets/ByteMonitor/byteMonitor.tsx
@@ -4,20 +4,22 @@ import {
   InferWidgetProps,
   ColorPropOpt,
   IntPropOpt,
-  BoolPropOpt
+  BoolPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { PVComponent, PVWidgetPropType } from "../widgetProps";
 import { registerWidget } from "../register";
 import classes from "./byteMonitor.module.css";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseToPixelInt } from "../utils";
 import { dTypeGetDoubleValue } from "../../../types/dtypes";
 import { useStyle } from "../../hooks/useStyle";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const widgetName = "bytemonitor";
 
 export const ByteMonitorProps = {
-  width: IntPropOpt,
+  width: StringPropOpt,
   height: IntPropOpt,
   onColor: ColorPropOpt,
   offColor: ColorPropOpt,
@@ -77,13 +79,18 @@ export const ByteMonitorComponent = (
   if (numBits < 1) numBits = 1;
   if (numBits > 64) numBits = 64;
 
+  const [ref, size] = useMeasuredSize<HTMLDivElement>(
+    parseToPixelInt(width, WIDGET_DEFAULT_SIZES["byte_monitor"][0]),
+    height
+  );
+
   const dataValues = getBytes(doubleValue, numBits, startBit, bitReverse);
   // If 3D effect, there is no border but we must leave space for shadow
   const border = effect3d ? 2 : ledBorder;
   const [bitWidth, bitHeight, borderWidth] = recalculateDimensions(
     numBits,
-    width,
-    height,
+    size.width,
+    size.height,
     border,
     horizontal,
     square
@@ -146,6 +153,7 @@ export const ByteMonitorComponent = (
 
   return (
     <div
+      ref={ref}
       className={classes.ByteMonitor}
       style={{ height: "100%", width: "100%" }}
     >

--- a/src/ui/widgets/ChoiceButton/choiceButton.test.tsx
+++ b/src/ui/widgets/ChoiceButton/choiceButton.test.tsx
@@ -105,7 +105,104 @@ describe("<ChoiceButton />", (): void => {
 
     expect(buttons[3]).toHaveStyle({
       cursor: "not-allowed",
-      height: "35px"
+      height: "35px",
+      width: "60px"
+    });
+  });
+
+  test("pass props to widget, for horizontal layout and pixel width", (): void => {
+    const choiceButtonProps = {
+      pvData: [
+        {
+          effectivePvName: "TEST:PV",
+          connected: true,
+          readonly: true,
+          value: newDType({ doubleValue: 0 })
+        } as Partial<PvDatum> as PvDatum
+      ],
+      width: 60,
+      height: 140,
+      font: newFont(12),
+      items: ["Choice", "Option", "Setting", "Custom"],
+      horizontal: true,
+      backgroundColor: ColorUtils.fromRgba(20, 20, 200),
+      selectedColor: ColorUtils.fromRgba(10, 60, 40),
+      itemsFromPv: false,
+      enabled: false
+    };
+    const { getAllByRole } = render(ChoiceButtonRenderer(choiceButtonProps));
+    const buttons = getAllByRole("button") as Array<HTMLButtonElement>;
+
+    expect(buttons.length).toEqual(4);
+    expect(buttons[2].textContent).toEqual("Setting");
+    expect(buttons[3]).toHaveProperty("disabled", true);
+
+    expect(buttons[0]).toHaveStyle({
+      "background-color": "rgb(0, 0, 0)",
+      "font-size": "0.75rem",
+      height: "140px",
+      width: "15px"
+    });
+    expect(buttons[1]).toHaveStyle({
+      height: "140px",
+      width: "15px"
+    });
+    expect(buttons[2]).toHaveStyle({
+      height: "140px",
+      width: "15px"
+    });
+    expect(buttons[3]).toHaveStyle({
+      cursor: "not-allowed",
+      height: "140px",
+      width: "15px"
+    });
+  });
+
+  test("pass props to widget, for horizontal layout and percentage width", (): void => {
+    const choiceButtonProps = {
+      pvData: [
+        {
+          effectivePvName: "TEST:PV",
+          connected: true,
+          readonly: true,
+          value: newDType({ doubleValue: 0 })
+        } as Partial<PvDatum> as PvDatum
+      ],
+      width: "100%",
+      height: 140,
+      font: newFont(12),
+      items: ["Choice", "Option", "Setting", "Custom"],
+      horizontal: true,
+      backgroundColor: ColorUtils.fromRgba(20, 20, 200),
+      selectedColor: ColorUtils.fromRgba(10, 60, 40),
+      itemsFromPv: false,
+      enabled: false
+    };
+    const { getAllByRole } = render(ChoiceButtonRenderer(choiceButtonProps));
+    const buttons = getAllByRole("button") as Array<HTMLButtonElement>;
+
+    expect(buttons.length).toEqual(4);
+    expect(buttons[2].textContent).toEqual("Setting");
+    expect(buttons[3]).toHaveProperty("disabled", true);
+
+    expect(buttons[0]).toHaveStyle({
+      "background-color": "rgb(0, 0, 0)",
+      "font-size": "0.75rem",
+      height: "140px",
+      width: "25%"
+    });
+    expect(buttons[1]).toHaveStyle({
+      height: "140px",
+      width: "25%"
+    });
+    expect(buttons[2]).toHaveStyle({
+      height: "140px",
+      width: "25%"
+    });
+    expect(buttons[3]).toHaveStyle({
+      cursor: "not-allowed",
+      height: "140px",
+      width: "25%"
     });
   });
 

--- a/src/ui/widgets/ChoiceButton/choiceButton.tsx
+++ b/src/ui/widgets/ChoiceButton/choiceButton.tsx
@@ -25,7 +25,7 @@ import {
   styled,
   ToggleButtonGroup
 } from "@mui/material";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseCssPositionValue } from "../utils";
 import { useStyle } from "../../hooks/useStyle";
 
 const widgetName = "choicebutton";
@@ -33,7 +33,7 @@ const widgetName = "choicebutton";
 const ChoiceButtonProps = {
   pvName: StringPropOpt,
   height: IntPropOpt,
-  width: IntPropOpt,
+  width: StringPropOpt,
   items: StringArrayPropOpt,
   selectedColor: ColorPropOpt,
   itemsFromPv: BoolPropOpt,
@@ -80,7 +80,7 @@ export const ChoiceButtonComponent = (
     widgetName
   );
   const {
-    width = 100,
+    width = "100",
     height = 43,
     pvData,
     enabled = true,
@@ -123,9 +123,11 @@ export const ChoiceButtonComponent = (
 
   // Number of buttons to create
   const numButtons = options.length || 1;
+
   // Determine width and height of buttons if horizontal or vertically placed
+  const { value: pixelWidth, unit } = parseCssPositionValue(width, 100);
   const buttonHeight = horizontal ? height : height / numButtons;
-  const buttonWidth = horizontal ? width / numButtons : width;
+  const buttonWidth = horizontal ? `${pixelWidth / numButtons}${unit}` : width;
 
   const handleChange = (event: any, newSelect: number) => {
     // Write to PV

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -63,6 +63,7 @@ export const DeviceComponent = (
       }
       setComponent(
         widgetDescriptionToComponent({
+          id: "123",
           position: newRelativePosition("100%", "100%"),
           type: "display",
           children: [componentDescription]

--- a/src/ui/widgets/Device/deviceParser.ts
+++ b/src/ui/widgets/Device/deviceParser.ts
@@ -51,6 +51,7 @@ export const wordSplitter = (word: string): string =>
 
 export function createLabel(value: string): WidgetDescription {
   return {
+    id: "123",
     type: "label",
     position: "relative",
     text: `${wordSplitter(value)}`,
@@ -62,6 +63,7 @@ export function createLabel(value: string): WidgetDescription {
 
 export function createReadback(pv: string): WidgetDescription {
   return {
+    id: "123",
     type: "readback",
     position: "relative",
     width: "45%",
@@ -72,6 +74,7 @@ export function createReadback(pv: string): WidgetDescription {
 
 export function createInput(pv: string): WidgetDescription {
   return {
+    id: "123",
     type: "input",
     position: "relative",
     width: "45%",
@@ -85,6 +88,7 @@ export function createButton(
   description?: string
 ): WidgetDescription {
   return {
+    id: "123",
     type: "actionbutton",
     position: "relative",
     width: "45%",

--- a/src/ui/widgets/DisplayResponsive/displayResponsive.test.tsx
+++ b/src/ui/widgets/DisplayResponsive/displayResponsive.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { DisplayResponsiveComponent } from "./displayResponsive";
+
+vi.mock("react-grid-layout", async () => {
+  const actual = await vi.importActual<any>("react-grid-layout");
+
+  return {
+    ...actual,
+
+    Responsive: ({ children }: any) => (
+      <div data-testid="rgl-responsive">{children}</div>
+    ),
+
+    useContainerWidth: () => ({
+      width: 1200,
+      mounted: true,
+      containerRef: { current: null }
+    })
+  };
+});
+
+const MockWidget = ({ id }: { id: string }) => (
+  <div data-testid={`widget-${id}`}>Widget {id}</div>
+);
+
+describe("DisplayResponsiveComponent", () => {
+  it("renders the responsive container", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    const container = document.querySelector(".display-responsive-container");
+
+    expect(container).toBeTruthy();
+  });
+
+  it("renders the Responsive grid when mounted", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("rgl-responsive")).toBeInTheDocument();
+  });
+
+  it("renders child widgets", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+        <MockWidget id="b" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("widget-a")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-b")).toBeInTheDocument();
+  });
+
+  it("wraps each child in a grid item div", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1">
+        <MockWidget id="a" />
+        <MockWidget id="b" />
+      </DisplayResponsiveComponent>
+    );
+
+    const grid = screen.getByTestId("rgl-responsive");
+
+    expect(grid.children.length).toBe(2);
+
+    expect(grid.children[0].firstElementChild).toHaveAttribute(
+      "data-testid",
+      "widget-a"
+    );
+
+    expect(grid.children[1].firstElementChild).toHaveAttribute(
+      "data-testid",
+      "widget-b"
+    );
+  });
+
+  it("accepts responsive configuration props", () => {
+    render(
+      <DisplayResponsiveComponent
+        id="display-1"
+        responsiveBreakpoints={{ lg: 1000, sm: 0 }}
+        responsiveColumns={{ lg: 10, sm: 4 }}
+        responsiveCellMargins={[8, 8]}
+        rowHeight="20"
+      >
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(screen.getByTestId("widget-a")).toBeInTheDocument();
+  });
+});

--- a/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
@@ -73,28 +73,37 @@ export const DisplayResponsiveComponent = (
   const [displayMacros, setDisplayMacros] = useState<MacroMap>(
     props.macros ?? {}
   );
-  const displayMacroContext: MacroContextType = {
-    updateMacro: (key: string, value: string): void => {
-      setDisplayMacros({ ...displayMacros, [key]: value });
-    },
-    macros: {
-      ...inheritedMacros, // lower priority
-      ...displayMacros, // higher priority
-      DID: props.id // highest priority
-    }
-  };
+
+  const updateMacro = React.useCallback((key: string, value: string) => {
+    setDisplayMacros(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  const displayMacroContext = React.useMemo<MacroContextType>(
+    () => ({
+      updateMacro,
+      macros: {
+        ...inheritedMacros,
+        ...displayMacros,
+        DID: props.id
+      }
+    }),
+    [updateMacro, inheritedMacros, displayMacros, props.id]
+  );
 
   // Get base style from common CSS
   const style = useStyle(props, widgetName);
-  const extendedStyle: React.CSSProperties = {
-    ...style.colors,
-    ...style.border,
-    ...style.other,
-    ...style.font,
-    position: "relative",
-    overflow: props.overflow,
-    height: "100%"
-  };
+  const extendedStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      ...style.colors,
+      ...style.border,
+      ...style.other,
+      ...style.font,
+      position: "relative",
+      overflow: props.overflow,
+      height: "100%"
+    }),
+    [style, props.overflow]
+  );
 
   const cellMargins = (props.responsiveCellMargins ?? defaultMArgins) as [
     number,
@@ -146,6 +155,7 @@ export const DisplayResponsiveComponent = (
       >
         {mounted && (
           <Responsive
+            key={`grid-${props.id}`}
             className="layout"
             layouts={layouts}
             breakpoints={breakpoints}

--- a/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayResponsive/displayResponsive.tsx
@@ -1,0 +1,235 @@
+import React, { useState, useContext, ReactNode } from "react";
+import {
+  Layout,
+  ResponsiveLayouts,
+  Responsive,
+  useContainerWidth,
+  Breakpoints
+} from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+import { Widget } from "../widget";
+import { PVWidgetComponent, WidgetPropType } from "../widgetProps";
+import { registerWidget } from "../register";
+import {
+  ChoicePropOpt,
+  ChildrenPropOpt,
+  InferWidgetProps,
+  ColorPropOpt,
+  BorderPropOpt,
+  MacrosPropOpt,
+  StringPropOpt,
+  BoolPropOpt,
+  StringArrayPropOpt,
+  ObjectPropOpt,
+  IntArrayPropOpt,
+  IntPropOpt
+} from "../propTypes";
+import {
+  MacroMap,
+  MacroContext,
+  MacroContextType
+} from "../../../types/macros";
+import { useStyle } from "../../hooks/useStyle";
+
+const widgetName = "displayResponsive";
+
+// Default grid configuration
+const defaultBreakpoints = { lg: 1200, md: 600, sm: 0 }; // These are minimum widths in pixels
+const defaultCols = { lg: 32, md: 16, sm: 8 };
+const defaultRowHeight = 15;
+const defaultMArgins = [6, 6];
+
+const DisplayResponsiveProps = {
+  children: ChildrenPropOpt,
+  overflow: ChoicePropOpt(["scroll", "hidden", "auto", "visible"]),
+  backgroundColor: ColorPropOpt,
+  border: BorderPropOpt,
+  macros: MacrosPropOpt,
+  scaling: StringArrayPropOpt,
+  autoZoomToFit: BoolPropOpt,
+  scalingOrigin: StringPropOpt,
+  // New props for Responsive react-grid-layout
+  responsiveLayouts: ObjectPropOpt,
+  responsiveBreakpoints: ObjectPropOpt,
+  responsiveColumns: ObjectPropOpt,
+  responsiveCellMargins: IntArrayPropOpt,
+  responsiveCellHeight: IntPropOpt,
+  rowHeight: StringPropOpt,
+  isDraggable: BoolPropOpt,
+  isResizable: BoolPropOpt
+};
+
+// Display widget that uses react-grid-layout to provide a responsive drag and drop container
+export const DisplayResponsiveComponent = (
+  props: InferWidgetProps<typeof DisplayResponsiveProps> & { id: string }
+): JSX.Element => {
+  // Macros specific to this display. Children of this component
+  // can set macros by using the updateMacro function on the
+  // context.
+  const { width, containerRef, mounted } = useContainerWidth();
+  const inheritedMacros: MacroMap = useContext(MacroContext).macros;
+  const [displayMacros, setDisplayMacros] = useState<MacroMap>(
+    props.macros ?? {}
+  );
+  const displayMacroContext: MacroContextType = {
+    updateMacro: (key: string, value: string): void => {
+      setDisplayMacros({ ...displayMacros, [key]: value });
+    },
+    macros: {
+      ...inheritedMacros, // lower priority
+      ...displayMacros, // higher priority
+      DID: props.id // highest priority
+    }
+  };
+
+  // Get base style from common CSS
+  const style = useStyle(props, widgetName);
+  const extendedStyle: React.CSSProperties = {
+    ...style.colors,
+    ...style.border,
+    ...style.other,
+    ...style.font,
+    position: "relative",
+    overflow: props.overflow,
+    height: "100%"
+  };
+
+  const cellMargins = (props.responsiveCellMargins ?? defaultMArgins) as [
+    number,
+    number
+  ];
+
+  const breakpoints = (props?.responsiveBreakpoints ??
+    defaultBreakpoints) as Breakpoints<string>;
+  const columns = (props.responsiveColumns ?? defaultCols) as Record<
+    string,
+    number
+  >;
+
+  const childrenArray = React.useMemo(
+    () =>
+      React.Children.toArray(props.children as ReactNode[]).filter(child =>
+        React.isValidElement<PVWidgetComponent>(child)
+      ),
+    [props.children]
+  );
+
+  const layouts = React.useMemo(
+    () =>
+      props?.responsiveLayouts ??
+      calculateDefaultLayouts(childrenArray, cellMargins),
+    [props.responsiveLayouts, childrenArray, cellMargins]
+  );
+
+  // Wrap the child components in a div keyed by the child id. The key MUST map to the i field of Layout item for the component.
+  const gridChildren = React.useMemo(
+    () =>
+      childrenArray.map(child => {
+        const id = child.props.id;
+        if (!id) {
+          throw new Error("All grid items must have a stable id");
+        }
+
+        return <div key={id}>{child}</div>;
+      }),
+    [childrenArray]
+  );
+
+  return (
+    <MacroContext.Provider value={displayMacroContext}>
+      <div
+        ref={containerRef as React.RefObject<HTMLDivElement>}
+        style={extendedStyle}
+        className="display-responsive-container"
+      >
+        {mounted && (
+          <Responsive
+            className="layout"
+            layouts={layouts}
+            breakpoints={breakpoints}
+            cols={columns}
+            rowHeight={Number(props.rowHeight ?? defaultRowHeight)}
+            margin={cellMargins}
+            width={width}
+            resizeConfig={{ enabled: false }}
+            style={{
+              ...style.colors,
+              ...style.font,
+              height: "100%"
+            }}
+          >
+            {gridChildren}
+          </Responsive>
+        )}
+      </div>
+    </MacroContext.Provider>
+  );
+};
+
+const DisplayResponsiveWidgetProps = {
+  ...DisplayResponsiveProps,
+  ...WidgetPropType
+};
+
+// This is a temporary function to calculate breakpoints if none are specified.
+// Note that width in columns and height should be defined by the parent not the child in RGL,
+// so this will need to change when we implement child resizing.
+const calculateDefaultLayouts = (
+  childrenArray: React.ReactElement<
+    PVWidgetComponent,
+    string | React.JSXElementConstructor<any>
+  >[],
+  cellMargins: [number, number]
+): ResponsiveLayouts => {
+  const gridMetadata = childrenArray.map(child => {
+    const width = child?.props?.position?.width
+      ? Math.ceil(
+          (Number(child?.props?.position?.width?.replace(/px$/, "")) +
+            cellMargins[0]) /
+            (40 + cellMargins[0])
+        )
+      : 1;
+    const height = child?.props?.position?.height
+      ? Math.ceil(
+          (Number(child?.props?.position?.height?.replace(/px$/, "")) +
+            cellMargins[1]) /
+            (defaultRowHeight + cellMargins[1])
+        )
+      : 1;
+    const id = child.props.id;
+
+    return { width, height, id };
+  });
+
+  return {
+    lg: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: (i % 3) * 4,
+      y: Math.floor(i / 3),
+      w: child?.width,
+      h: child?.height
+    })) as Layout,
+    md: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: (i % 2) * 5,
+      y: Math.floor(i / 2),
+      w: child?.width,
+      h: child?.height
+    })) as Layout,
+    sm: gridMetadata?.map((child, i) => ({
+      i: child?.id,
+      x: 0,
+      y: i,
+      w: child?.width,
+      h: child?.height
+    })) as Layout
+  };
+};
+
+export const DisplayResponsive = (
+  props: InferWidgetProps<typeof DisplayResponsiveWidgetProps>
+): JSX.Element => <Widget baseWidget={DisplayResponsiveComponent} {...props} />;
+
+registerWidget(DisplayResponsive, DisplayResponsiveWidgetProps, widgetName);

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { bobParseNumber, bobParseNumberMandatory } from "./baseBobParsers";
+
+const element = (_text: any) => ({ _text });
+
+describe("bobParseNumber", () => {
+  it("parses a valid integer string", () => {
+    const result = bobParseNumber(element("42"));
+    expect(result).toBe(42);
+  });
+
+  it("parses a valid float string", () => {
+    const result = bobParseNumber(element("3.14"));
+    expect(result).toBe(3.14);
+  });
+
+  it("returns NaN for non-numeric strings", () => {
+    const result = bobParseNumber(element("not-a-number"));
+    expect(result).toBeNaN();
+  });
+
+  it("returns NaN when _text is undefined", () => {
+    const result = bobParseNumber({} as any);
+    expect(result).toBeNaN();
+  });
+
+  it("returns undefined if accessing _text throws", () => {
+    const badElement = {
+      get _text() {
+        throw new Error("boom");
+      }
+    };
+
+    const result = bobParseNumber(badElement as any);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("bobParseNumberMandatory", () => {
+  it("parses a valid integer string", () => {
+    const result = bobParseNumberMandatory(element("100"));
+    expect(result).toBe(100);
+  });
+
+  it("parses a valid float string", () => {
+    const result = bobParseNumberMandatory(element("2.5"));
+    expect(result).toBe(2.5);
+  });
+
+  it("returns NaN for non-numeric strings (does NOT throw)", () => {
+    const result = bobParseNumberMandatory(element("invalid"));
+    expect(result).toBeNaN();
+  });
+
+  it("throws if accessing _text throws", () => {
+    const badElement = {
+      get _text() {
+        throw new Error("boom");
+      }
+    };
+
+    expect(() => bobParseNumberMandatory(badElement as any)).toThrowError(
+      "Could not parse number from value undefined."
+    );
+  });
+});

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/baseBobParsers.ts
@@ -1,0 +1,20 @@
+import { ElementCompact } from "xml-js";
+
+export function bobParseNumber(jsonProp: ElementCompact): number | undefined {
+  try {
+    return Number(jsonProp._text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function bobParseNumberMandatory(jsonProp: ElementCompact): number {
+  let rawValue: any;
+
+  try {
+    rawValue = jsonProp._text;
+    return Number(jsonProp._text);
+  } catch {
+    throw new Error(`Could not parse number from value ${rawValue}.`);
+  }
+}

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import log from "loglevel";
+import { opiParseString } from "../opiParser";
+import { bobParseNumber } from "./baseBobParsers";
+
+import {
+  bobParseStringNumberMap,
+  bobParseResponsiveBreakpoints,
+  bobParseResponsiveMargins,
+  bobParseResponsiveColumns,
+  bobParseResponsiveLayout
+} from "./responsiveLayoutBobParser";
+
+vi.mock("../opiParser", () => ({
+  opiParseString: vi.fn()
+}));
+
+vi.mock("./baseBobParsers", () => ({
+  bobParseNumber: vi.fn()
+}));
+
+vi.mock("loglevel", () => ({
+  default: {
+    error: vi.fn()
+  }
+}));
+
+const asElementCompact = (obj: any) => obj;
+
+describe("bobParseStringNumberMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps string keys to parsed numeric values", () => {
+    (bobParseNumber as any).mockReturnValueOnce(1200).mockReturnValueOnce(600);
+
+    const input = asElementCompact({
+      lg: "1200",
+      md: "600"
+    });
+
+    const result = bobParseStringNumberMap(input);
+
+    expect(result).toEqual({
+      lg: 1200,
+      md: 600
+    });
+
+    expect(bobParseNumber).toHaveBeenCalledTimes(2);
+  });
+
+  it("filters out null values", () => {
+    (bobParseNumber as any).mockReturnValueOnce(1200).mockReturnValueOnce(null);
+
+    const input = asElementCompact({
+      lg: "1200",
+      md: "invalid"
+    });
+
+    const result = bobParseStringNumberMap(input);
+
+    expect(result).toEqual({
+      lg: 1200
+    });
+  });
+});
+
+describe("bobParseResponsiveBreakpoints", () => {
+  it("delegates to bobParseStringNumberMap", () => {
+    (bobParseNumber as any).mockReturnValue(1000);
+
+    const result = bobParseResponsiveBreakpoints(
+      asElementCompact({ lg: "1000" })
+    );
+
+    expect(result).toEqual({ lg: 1000 });
+  });
+});
+
+describe("bobParseResponsiveColumns", () => {
+  it("delegates to bobParseStringNumberMap", () => {
+    (bobParseNumber as any).mockReturnValue(12);
+
+    const result = bobParseResponsiveColumns(asElementCompact({ lg: "12" }));
+
+    expect(result).toEqual({ lg: 12 });
+  });
+});
+
+describe("bobParseResponsiveMargins", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses two space-separated numbers", () => {
+    (opiParseString as any).mockReturnValue("10 20");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([10, 20]);
+  });
+
+  it("defaults missing second value", () => {
+    (opiParseString as any).mockReturnValue("8");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([8, 6]);
+  });
+
+  it("falls back to default margins on invalid numbers", () => {
+    (opiParseString as any).mockReturnValue("10 nope");
+
+    const result = bobParseResponsiveMargins(asElementCompact({}));
+
+    expect(result).toEqual([6, 6]);
+    expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe("bobParseResponsiveLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses responsive layouts correctly", () => {
+    const input = asElementCompact({
+      lg: {
+        element_position: [
+          {
+            _attributes: {
+              i: "a",
+              x: "0",
+              y: "1",
+              w: "4",
+              h: "2"
+            }
+          }
+        ]
+      }
+    });
+
+    const result = bobParseResponsiveLayout(input);
+
+    expect(result).toEqual({
+      lg: [
+        {
+          i: "a",
+          x: 0,
+          y: 1,
+          w: 4,
+          h: 2
+        }
+      ]
+    });
+  });
+
+  it("returns empty arrays when no positions exist", () => {
+    const input = asElementCompact({
+      lg: {
+        element_position: []
+      }
+    });
+
+    const result = bobParseResponsiveLayout(input);
+
+    expect(result).toEqual({
+      lg: []
+    });
+  });
+
+  it("returns empty object if parsing throws", () => {
+    const badInput = null as any;
+
+    const result = bobParseResponsiveLayout(badInput);
+
+    expect(result).toEqual({});
+    expect(log.error).toHaveBeenCalled();
+  });
+});

--- a/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/BobParsers/responsiveLayoutBobParser.ts
@@ -1,0 +1,86 @@
+import { ElementCompact } from "xml-js";
+import log from "loglevel";
+import {
+  ResponsiveBreakpoints,
+  ResponsiveColumns,
+  ResponsiveGridLayout,
+  ResponsiveLayout,
+  ResponsiveLayoutItem
+} from "../../../../types/responsiveBreakpoints";
+import { opiParseString } from "../opiParser";
+import { bobParseNumber } from "./baseBobParsers";
+
+export const bobParseStringNumberMap = (
+  jsonProp: ElementCompact
+): ResponsiveBreakpoints =>
+  Object.fromEntries(
+    Object.entries(jsonProp)
+      .map(([key, value]) => [key, bobParseNumber(value)])
+      .filter(x => x[1] != null)
+  );
+
+export const bobParseResponsiveBreakpoints = (
+  jsonProp: ElementCompact
+): ResponsiveBreakpoints => bobParseStringNumberMap(jsonProp);
+
+export const bobParseResponsiveMargins = (
+  jsonProp: ElementCompact
+): [number, number] => {
+  const spaceSeparatedArray = opiParseString(jsonProp);
+
+  const margins = spaceSeparatedArray?.trim()?.split(/\s+/)?.map(Number);
+
+  if (margins.some(v => !Number.isFinite(Number(v)))) {
+    log.error(
+      "Invalid number in space separated number array: ",
+      spaceSeparatedArray
+    );
+    return [6, 6];
+  }
+
+  return [margins[0] ?? 6, margins[1] ?? 6];
+};
+
+export const bobParseResponsiveColumns = (
+  jsonProp: ElementCompact
+): ResponsiveColumns => bobParseStringNumberMap(jsonProp);
+
+export const bobParseResponsiveLayout = (
+  jsonProp: ElementCompact
+): ResponsiveGridLayout => {
+  try {
+    return Object.fromEntries(
+      Object.entries(jsonProp)
+        .map(([key, value]) => [key, bobParseResponsiveComponentLayouts(value)])
+        .filter(x => x[1] != null)
+    );
+  } catch (error) {
+    log.error("bobParser: Failed to parse a responsive layout");
+    log.error(error);
+    return {};
+  }
+};
+
+const bobParseResponsiveComponentLayouts = (
+  jsonProp: ElementCompact
+): ResponsiveLayout => {
+  if (!jsonProp?.element_position || jsonProp?.element_position?.length === 0) {
+    return [];
+  }
+
+  return jsonProp.element_position
+    .filter((element: ElementCompact) => !!element?._attributes)
+    .map((element: ElementCompact) =>
+      bobParseResponsiveItem(element._attributes as ElementCompact)
+    );
+};
+
+const bobParseResponsiveItem = (
+  jsonProp: ElementCompact
+): ResponsiveLayoutItem => ({
+  i: jsonProp?.i,
+  x: Number(jsonProp?.x),
+  y: Number(jsonProp?.y),
+  w: Number(jsonProp?.w),
+  h: Number(jsonProp?.h)
+});

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
@@ -1,6 +1,10 @@
 import { ColorUtils } from "../../../types/color";
 import { newAbsolutePosition } from "../../../types/position";
-import { BOB_SIMPLE_PARSERS, parseBob } from "./bobParser";
+import {
+  BOB_SIMPLE_PARSERS,
+  normalizeCssPosition,
+  parseBob
+} from "./bobParser";
 import { PVUtils } from "../../../types/pv";
 import { ensureWidgetsRegistered } from "..";
 import { WidgetDescription } from "../createComponent";
@@ -340,5 +344,56 @@ describe("bobParseSymbols", () => {
 
     expect(() => bobParseSymbols(input)).not.toThrow();
     expect(bobParseSymbols(input)).toEqual(["IBM", "ORCL"]);
+  });
+});
+
+describe("normalizeCssPosition", () => {
+  const DEFAULT = 10;
+
+  it("returns defaultValue in px when value is null or undefined", () => {
+    expect(normalizeCssPosition(null as any, DEFAULT)).toBe("10px");
+    expect(normalizeCssPosition(undefined as any, DEFAULT)).toBe("10px");
+  });
+
+  it("appends px when value is a number", () => {
+    expect(normalizeCssPosition(0 as any, DEFAULT)).toBe("0px");
+    expect(normalizeCssPosition(25 as any, DEFAULT)).toBe("25px");
+    expect(normalizeCssPosition(-5 as any, DEFAULT)).toBe("-5px");
+  });
+
+  it("returns value unchanged when value is not a string or number", () => {
+    const obj = { top: 10 };
+    const arr = [10];
+
+    expect(normalizeCssPosition(obj as any, DEFAULT)).toBe(obj);
+    expect(normalizeCssPosition(arr as any, DEFAULT)).toBe(arr);
+  });
+
+  it("appends px when value is a numeric string", () => {
+    expect(normalizeCssPosition("10", DEFAULT)).toBe("10px");
+    expect(normalizeCssPosition(" 20 ", DEFAULT)).toBe("20px");
+    expect(normalizeCssPosition("-5", DEFAULT)).toBe("-5px");
+    expect(normalizeCssPosition("2.5", DEFAULT)).toBe("2.5px");
+  });
+
+  it("returns original string when value already contains a CSS unit", () => {
+    expect(normalizeCssPosition("10px", DEFAULT)).toBe("10px");
+    expect(normalizeCssPosition("50%", DEFAULT)).toBe("50%");
+    expect(normalizeCssPosition("2rem", DEFAULT)).toBe("2rem");
+    expect(normalizeCssPosition("1.5em", DEFAULT)).toBe("1.5em");
+  });
+
+  it("returns original string for non-numeric CSS values", () => {
+    expect(normalizeCssPosition("auto", DEFAULT)).toBe("auto");
+    expect(normalizeCssPosition("inherit", DEFAULT)).toBe("inherit");
+    expect(normalizeCssPosition("calc(100% - 10px)", DEFAULT)).toBe(
+      "calc(100% - 10px)"
+    );
+  });
+
+  it("does not partially parse invalid numeric strings", () => {
+    expect(normalizeCssPosition("10pxfoo", DEFAULT)).toBe("10pxfoo");
+    expect(normalizeCssPosition("px10", DEFAULT)).toBe("px10");
+    expect(normalizeCssPosition("10.5.3", DEFAULT)).toBe("10.5.3");
   });
 });

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -138,13 +138,39 @@ function bobParseType(props: any): string {
   }
 }
 
+export const normalizeCssPosition = (
+  value: string | undefined,
+  defaultValue: number
+) => {
+  if (value == null) {
+    return `${defaultValue}px`;
+  }
+
+  if (typeof value === "number") {
+    return `${value}px`;
+  }
+
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  // numeric string, append px
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return `${trimmed}px`;
+  }
+
+  return value;
+};
+
 function bobParsePosition(props: any): Position {
   // Find type of widget and map to default width and height for that widget
   const widget = props._attributes.type;
   return newAbsolutePosition(
     `${bobParseNumber(props.x) ?? 0}px`,
     `${bobParseNumber(props.y) ?? 0}px`,
-    `${bobParseNumber(props.width) ?? WIDGET_DEFAULT_SIZES[widget][0]}px`,
+    normalizeCssPosition(props.width?._text, WIDGET_DEFAULT_SIZES[widget][0]),
     `${bobParseNumber(props.height) ?? WIDGET_DEFAULT_SIZES[widget][1]}px`
   );
 }

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -49,6 +49,13 @@ import { Trace } from "../../../types/trace";
 import { parsePlt } from "./pltParser";
 import { scriptParser } from "./scripts/scriptParser";
 import { MacroMap } from "../../../types/macros";
+import { bobParseNumber } from "./BobParsers/baseBobParsers";
+import {
+  bobParseResponsiveBreakpoints,
+  bobParseResponsiveColumns,
+  bobParseResponsiveLayout,
+  bobParseResponsiveMargins
+} from "./BobParsers/responsiveLayoutBobParser";
 
 const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   action_button: "actionbutton",
@@ -59,6 +66,7 @@ const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   combo: "menubutton",
   databrowser: "databrowser",
   display: "display",
+  displayResponsive: "displayResponsive",
   ellipse: "ellipse",
   embedded: "embeddedDisplay",
   group: "groupbox",
@@ -96,6 +104,7 @@ export const WIDGET_DEFAULT_SIZES: { [key: string]: [number, number] } = {
   combo: [100, 30],
   databrowser: [400, 300],
   display: [800, 800],
+  displayResponsive: [800, 800],
   ellipse: [100, 50],
   embedded: [400, 300],
   group: [300, 200],
@@ -126,14 +135,6 @@ function bobParseType(props: any): string {
     return BOB_WIDGET_MAPPING[typeId];
   } else {
     return typeId;
-  }
-}
-
-export function bobParseNumber(jsonProp: ElementCompact): number | undefined {
-  try {
-    return Number(jsonProp._text);
-  } catch {
-    return undefined;
   }
 }
 
@@ -494,6 +495,7 @@ function bobGetTargetWidget(props: any): {
 
 export const BOB_SIMPLE_PARSERS: ParserDict = {
   ...OPI_SIMPLE_PARSERS,
+  id: ["id", opiParseString],
   font: ["font", bobParseFont],
   items: ["items", bobParseItems],
   imageFile: ["file", opiParseString],
@@ -555,6 +557,14 @@ export const BOB_SIMPLE_PARSERS: ParserDict = {
   end: ["end", opiParseString],
   arrayIndex: ["array_index", bobParseNumber],
   direction: ["direction", bobParseNumber],
+  responsiveLayouts: ["responsive_layouts", bobParseResponsiveLayout],
+  responsiveBreakpoints: [
+    "responsive_breakpoints",
+    bobParseResponsiveBreakpoints
+  ],
+  responsiveColumns: ["responsive_columns", bobParseResponsiveColumns],
+  responsiveCellMargins: ["responsive_cell_margins", bobParseResponsiveMargins],
+  responsiveCellHeight: ["responsive_cell_height", bobParseNumber],
   tabWidth: ["tab_width", bobParseNumber],
   tabHeight: ["tab_height", bobParseNumber],
   tabSpacing: ["tab_spacing", bobParseNumber],
@@ -581,7 +591,18 @@ export async function parseBob(
   const compactJSON = xml2js(xmlString, {
     compact: true
   }) as XmlDescription;
-  compactJSON.display._attributes.type = "display";
+  const display = compactJSON?.display ?? compactJSON?.displayResponsive;
+  const displayAttributes = {
+    ...display,
+    _attributes: {
+      ...display._attributes,
+      type: compactJSON?.display ? "display" : "displayResponsive"
+    },
+    x: { _text: "0" },
+    y: { _text: "0" }
+  };
+
+  compactJSON["display"] = displayAttributes;
   log.debug(compactJSON);
 
   const simpleParsers: ParserDict = {

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
@@ -270,7 +270,10 @@ describe("<EmbeddedDisplay>", (): void => {
 
     const display = container.querySelector(".display");
     expect(display).not.toBeNull();
-    const innerDisplayWidgetWrapper = display?.firstElementChild;
+
+    const innerDisplayWidgetWrapper =
+      display?.firstElementChild?.firstElementChild;
+
     expect(innerDisplayWidgetWrapper).toHaveStyle("position: absolute");
 
     // This should match the size of the selected group
@@ -282,7 +285,7 @@ describe("<EmbeddedDisplay>", (): void => {
 
     const displayInner = display?.querySelector(".display");
     expect(displayInner).not.toBeNull();
-    const groupBoxWidgetWrapper = displayInner?.firstChild;
+    const groupBoxWidgetWrapper = displayInner?.firstChild?.firstChild;
     expect(groupBoxWidgetWrapper).toHaveStyle("position: absolute");
     expect(groupBoxWidgetWrapper).toHaveStyle("height: 250px");
     expect(groupBoxWidgetWrapper).toHaveStyle("width: 240px");

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -62,7 +62,7 @@ export const EmbeddedDisplay = (
   props: InferWidgetProps<typeof EmbeddedDisplayProps> &
     EmbeddedDisplayPropsExtra
 ): JSX.Element => {
-  const id = useId();
+  const [id] = useId();
 
   // First resolve the macros
   // Include and override parent macros with those from the prop.
@@ -251,6 +251,7 @@ export const EmbeddedDisplay = (
   try {
     component = widgetDescriptionToComponent({
       type: "display",
+      id: `display_${crypto.randomUUID()}`,
       position: resolvedProps.position,
       backgroundColor:
         selectedDescription.backgroundColor ?? newColor("rgb(255,255,255"),

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -670,7 +670,7 @@ export const OPI_SIMPLE_PARSERS: ParserDict = {
   tooltip: ["tooltip", opiParseString],
   stretchToFit: ["stretch_to_fit", opiParseBoolean],
   lineWidth: ["line_width", opiParseNumber],
-  width: ["width", opiParseNumber],
+  width: ["width", opiParseString],
   height: ["height", opiParseNumber],
   label: ["label", opiParseString],
   opiFile: ["opi_file", opiParseString],

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -1001,7 +1001,7 @@ export async function parseOpi(
   };
 
   const displayWidget = await parseWidget(
-    compactJSON.display,
+    compactJSON?.display ?? compactJSON?.displayResponsive,
     opiGetTargetWidget,
     "widget",
     simpleParsers,

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -129,6 +129,11 @@ export async function genericParser(
     }));
   }
 
+  // attach an id if it does not exist
+  if (!newProps?.id) {
+    newProps["id"] = `${newProps.type}_${crypto.randomUUID()}`;
+  }
+
   return newProps;
 }
 

--- a/src/ui/widgets/LED/led.test.tsx
+++ b/src/ui/widgets/LED/led.test.tsx
@@ -96,31 +96,30 @@ describe("background color changes depending on value", (): void => {
   });
 });
 
-describe("width property is used", (): void => {
-  it("width changes the size of the LED", (): void => {
-    const renderedLed = renderLed({ ...DEFAULT_PROPS, width: 10 });
+describe("Round LED", (): void => {
+  it("width and height set to 100%", (): void => {
+    const renderedLed = renderLed({ ...DEFAULT_PROPS });
 
     // Width in CS-Studio doesn't quite match width in the browser,
     // so whatever is input has 5 subtracted from it, this makes it
     // look more like CS-Studio
-    expect(renderedLed.props.style.width).toBe("10px");
-    expect(renderedLed.props.style.height).toBe("20px");
+    expect(renderedLed.props.style.width).toBe("100%");
+    expect(renderedLed.props.style.height).toBe("100%");
   });
 });
 
-describe("height property is used", (): void => {
-  it("height changes the size of the LED", (): void => {
+describe("Square LED", (): void => {
+  it("width and height set to 100%", (): void => {
     const renderedLed = renderLed({
       ...DEFAULT_PROPS,
-      height: 10,
       square: true
     });
 
     // Width in CS-Studio doesn't quite match width in the browser,
     // so whatever is input has 5 subtracted from it, this makes it
     // look more like CS-Studio
-    expect(renderedLed.props.style.width).toBe("20px");
-    expect(renderedLed.props.style.height).toBe("10px");
+    expect(renderedLed.props.style.width).toBe("100%");
+    expect(renderedLed.props.style.height).toBe("100%");
     expect(renderedLed.props.style.borderRadius).toBe("0%");
   });
 });

--- a/src/ui/widgets/LED/led.tsx
+++ b/src/ui/widgets/LED/led.tsx
@@ -4,13 +4,11 @@ import {
   InferWidgetProps,
   ColorPropOpt,
   IntPropOpt,
-  BoolPropOpt,
-  FloatPropOpt
+  BoolPropOpt
 } from "../propTypes";
 import { PVComponent, PVWidgetPropType } from "../widgetProps";
 import { registerWidget } from "../register";
 import classes from "./led.module.css";
-import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 import { getPvValueAndName } from "../utils";
 import {
   dTypeGetAlarm,
@@ -25,8 +23,6 @@ const widgetName = "led";
  * width: the diameter of the LED
  */
 export const LedProps = {
-  width: FloatPropOpt,
-  height: FloatPropOpt,
   onColor: ColorPropOpt,
   offColor: ColorPropOpt,
   lineColor: ColorPropOpt,
@@ -44,14 +40,7 @@ export type LedComponentProps = InferWidgetProps<typeof LedProps> & PVComponent;
  * tooltip property in a json file containing a led
  */
 export const LedComponent = (props: LedComponentProps): JSX.Element => {
-  const {
-    pvData,
-    width = WIDGET_DEFAULT_SIZES["led"][0],
-    height = WIDGET_DEFAULT_SIZES["led"][1],
-    alarmSensitive = false,
-    bit = -1,
-    square = false
-  } = props;
+  const { pvData, alarmSensitive = false, bit = -1, square = false } = props;
 
   const style = useStyle(
     {
@@ -86,11 +75,8 @@ export const LedComponent = (props: LedComponentProps): JSX.Element => {
     : style?.customColors?.offColor;
   divStyle["border"] = `2px solid ${style?.customColors?.lineColor}`;
   divStyle["borderRadius"] = square ? "0%" : "50%";
-
-  // make sizes similar to size in CS-Studio, five taken
-  // away from default in css file too
-  divStyle.width = `${width}px`;
-  divStyle.height = `${height}px`;
+  divStyle.width = "100%";
+  divStyle.height = "100%";
 
   let className = classes.Led;
   if (alarmSensitive) {

--- a/src/ui/widgets/Meter/meter.test.tsx
+++ b/src/ui/widgets/Meter/meter.test.tsx
@@ -20,6 +20,10 @@ vi.mock("../../hooks/useStyle", () => ({
   )
 }));
 
+vi.mock("../../hooks/useMeasuredSize", () => ({
+  useMeasuredSize: () => [{ current: null }, { width: 240, height: 120 }]
+}));
+
 vi.mock("react-gauge-component", () => ({
   GaugeComponent: vi.fn(({ value, minValue, maxValue, labels, style }) => (
     <div
@@ -170,32 +174,32 @@ describe("MeterComponent", () => {
   });
 
   it("scales width correctly based on height/width ratio", () => {
-    render(<MeterComponent {...defaultProps} height={100} width={300} />);
+    render(<MeterComponent {...defaultProps} height={100} width={"300"} />);
 
     const gauge = screen.getByTestId("gauge-component");
     expect(JSON.parse(gauge.getAttribute("data-style") ?? "{}").width).toBe(
-      190
+      "190px"
     ); // scaled width
   });
 
   it("uses 100% parent box width when width/height ratio is greater than 1.9", () => {
-    render(<MeterComponent {...defaultProps} height={100} width={300} />);
+    render(<MeterComponent {...defaultProps} height={100} width={"300"} />);
 
     const box = screen.getByTestId("gauge-component").parentElement;
     expect(box).toHaveStyle("width: 100%");
   });
 
   it("uses width when width/height ratio is less than 1.9", () => {
-    render(<MeterComponent {...defaultProps} height={100} width={150} />);
+    render(<MeterComponent {...defaultProps} height={100} width={"150"} />);
 
     const gauge = screen.getByTestId("gauge-component");
     expect(JSON.parse(gauge.getAttribute("data-style") ?? "{}").width).toBe(
-      150
+      "190px"
     ); // specified width
   });
 
   it("uses 100% parent box width when width/height ratio is less than 1.9", () => {
-    render(<MeterComponent {...defaultProps} height={100} width={150} />);
+    render(<MeterComponent {...defaultProps} height={100} width={"150"} />);
 
     const box = screen.getByTestId("gauge-component").parentElement;
     expect(box).toHaveStyle("width: 100%");

--- a/src/ui/widgets/Meter/meter.tsx
+++ b/src/ui/widgets/Meter/meter.tsx
@@ -9,7 +9,8 @@ import {
   IntPropOpt,
   InferWidgetProps,
   FontPropOpt,
-  ColorPropOpt
+  ColorPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { GaugeComponent } from "react-gauge-component";
 import {
@@ -20,9 +21,10 @@ import {
   formatValue,
   NumberFormatEnum
 } from "./meterUtilities";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseCssPositionValue } from "../utils";
 import { dTypeGetDoubleValue } from "../../../types/dtypes";
 import { useStyle } from "../../hooks/useStyle";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const widgetName = "meter";
 
@@ -39,7 +41,7 @@ export const MeterProps = {
   transparent: BoolPropOpt,
   showUnits: BoolPropOpt,
   showValue: BoolPropOpt,
-  width: FloatPropOpt,
+  width: StringPropOpt,
   height: FloatPropOpt
 };
 
@@ -56,6 +58,9 @@ export const MeterComponent = (
     showUnits = true,
     showValue = true
   } = props;
+  const { value: widthNum } = parseCssPositionValue(width, 240);
+  const [ref, size] = useMeasuredSize(widthNum, height);
+
   const style = useStyle(
     { ...props, customColors: { needleColor: props?.needleColor } },
     widgetName
@@ -86,37 +91,40 @@ export const MeterComponent = (
       display?.controlRange?.min ?? alarmRangeMin ?? warningRangeMin;
     const pvMax =
       display?.controlRange?.max ?? alarmRangeMax ?? warningRangeMax;
-    minimum = pvMin ?? 0;
-    maximum = pvMax ?? 100;
+    minimum = pvMin ?? minimum;
+    maximum = pvMax ?? maximum;
   }
 
   // For a semi semicircle height / width is 2, but allow extra height for some padding
-  const scaledWidth = width / height > 1.9 ? 1.9 * height : width;
+  const scaledWidth =
+    size.width && size.width / height > 1.9 ? 1.9 * height : (size.width ?? 0);
 
   // Calculate the tick positions and the string labels
   const tickPositions = createTickPositions(minimum, maximum);
   const tickLabels = formatTickLabels(tickPositions);
 
+  const remountKey = useMemo(() => {
+    if (!scaledWidth || scaledWidth < 10) return "gauge-init";
+    return `gauge-${Math.round(scaledWidth)}`;
+  }, [scaledWidth]);
+
   return (
     <Box
-      alignItems="center"
-      justifyItems="center"
-      alignContent="center"
-      justifyContent="center"
+      ref={ref}
       sx={{
         ...style.colors,
         display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         height: "100%",
-        width: "100%",
-        position: "absolute"
+        width: "100%"
       }}
     >
       <GaugeComponent
+        key={remountKey}
         style={{
           height: "100%",
-          width: scaledWidth,
-          display: "flex",
-          position: "absolute",
+          width: `${scaledWidth}px`,
           backgroundColor: "transparent"
         }}
         value={numValue}
@@ -134,7 +142,7 @@ export const MeterComponent = (
           color: style?.customColors?.needleColor,
           baseColor: style?.customColors?.needleColor,
           elastic: false,
-          animate: false,
+          animate: true,
           length: 0.95,
           width: 15
         }}

--- a/src/ui/widgets/SimpleSymbol/simpleSymbol.test.tsx
+++ b/src/ui/widgets/SimpleSymbol/simpleSymbol.test.tsx
@@ -2,8 +2,16 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { SimpleSymbolComponent } from "./simpleSymbol";
 import { newDType } from "../../../types/dtypes";
+import { vi } from "vitest";
 
 const fakeValue = newDType({ stringValue: "Fake value" });
+
+vi.mock("../../hooks/useMeasuredSize", () => ({
+  useMeasuredSize: (width: number, height: number) => [
+    { current: null },
+    { width, height }
+  ]
+}));
 
 describe("<Symbol />", (): void => {
   test("img element rendered", (): void => {

--- a/src/ui/widgets/SimpleSymbol/simpleSymbol.tsx
+++ b/src/ui/widgets/SimpleSymbol/simpleSymbol.tsx
@@ -17,11 +17,13 @@ import { registerWidget } from "../register";
 import { executeActions, WidgetActions } from "../widgetActions";
 import { MacroContext } from "../../../types/macros";
 import { ExitFileContext, FileContext } from "../../../misc/fileContext";
+import { parseToPixelInt } from "../utils";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const SimpleSymbolProps = {
   imageFile: StringProp,
   imageIndex: IntProp,
-  width: IntProp,
+  width: StringProp,
   height: IntProp,
   backgroundColor: ColorPropOpt,
   border: BorderPropOpt,
@@ -58,13 +60,20 @@ export const SimpleSymbolComponent = (
     }
   }
   // Render the imageIndex-th part of the larger png.
-  const left = props.width * props.imageIndex;
-  const right = props.width * (props.imageIndex + 1);
-  const clip = `rect(0 ${right}px ${props.height}px ${left}px)`;
+  const pixelWidth = parseToPixelInt(props.width, 50);
+  const [ref, size] = useMeasuredSize<HTMLImageElement>(
+    pixelWidth,
+    props.height
+  );
+
+  const left = size.width * props.imageIndex;
+  const right = size.width * (props.imageIndex + 1);
+  const clip = `rect(0 ${right}px ${size.height}px ${left}px)`;
   const margin = `0 -${left}px 0 -${left}px`;
 
   return (
     <img
+      ref={ref}
       src={props.imageFile}
       alt="Simple symbol widget"
       onClick={onClick}

--- a/src/ui/widgets/SlideControl/slideControl.test.tsx
+++ b/src/ui/widgets/SlideControl/slideControl.test.tsx
@@ -9,6 +9,13 @@ vi.mock("../../hooks/useStyle", () => ({
   useStyle: vi.fn(() => createMockStyle())
 }));
 
+vi.mock("../../hooks/useMeasuredSize", () => ({
+  useMeasuredSize: (width: number, height: number) => [
+    { current: null },
+    { width, height }
+  ]
+}));
+
 test("slideControl", () => {
   const { container } = render(
     <SlideControlComponent

--- a/src/ui/widgets/SlideControl/slideControl.tsx
+++ b/src/ui/widgets/SlideControl/slideControl.tsx
@@ -11,14 +11,16 @@ import {
   FloatPropOpt,
   FontPropOpt,
   InferWidgetProps,
-  IntPropOpt
+  IntPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 import { dTypeGetDoubleValue, newDType } from "../../../types/dtypes";
 import { Slider } from "@mui/material";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseCssPositionValue } from "../utils";
 import { useStyle } from "../../hooks/useStyle";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
 
 const widgetName = "slidecontrol";
 
@@ -47,7 +49,7 @@ export const SliderControlProps = {
   showLolo: BoolPropOpt,
   increment: FloatPropOpt,
   majorTickStepHint: IntPropOpt,
-  width: FloatPropOpt,
+  width: StringPropOpt,
   height: FloatPropOpt
 };
 
@@ -93,8 +95,14 @@ export const SlideControlComponent = (
   let tickInterval;
 
   // Calculate number of ticks to show
+  const { value: widthNum } = parseCssPositionValue(
+    width,
+    WIDGET_DEFAULT_SIZES["scaledslider"][0]
+  );
+  const [ref, size] = useMeasuredSize<HTMLDivElement>(widthNum, height);
+
   let numOfTicks = Math.round(
-    (horizontal ? width : height) / majorTickStepHint
+    (horizontal ? size.width : size.height) / majorTickStepHint
   );
   if (numOfTicks > 15) numOfTicks = 15; // Phoebus roughly has a maximum of 15 ticks
   // Check if the number of ticks makes equal markers, iterate until we find good value
@@ -186,45 +194,55 @@ export const SlideControlComponent = (
   ]);
 
   return (
-    <Slider
-      value={inputValue}
-      disabled={readOnly || !enabled}
-      orientation={horizontal ? "horizontal" : "vertical"}
-      onChange={(_, newValue) => setInputValue(newValue as number)}
-      onChangeCommitted={(_, newValue) => onMouseUp(newValue as number)}
-      valueLabelDisplay="auto"
-      min={minimum}
-      max={maximum}
-      marks={marks}
-      step={increment}
-      sx={{
-        cursor: readOnly ? "not-allowed" : "default",
-        color: style?.colors?.color,
-        "& .MuiSlider-thumb": {
-          height: 16,
-          width: 16,
-          backgroundColor: "white",
-          border: "2px solid currentColor",
-          "&:focus, &:hover, &.Mui-active, &.Mui-focusVisible": {
-            boxShadow: "inherit"
-          }
-        },
-        "& .MuiSlider-valueLabelOpen": {
-          ...style?.colors,
-          ...style?.font,
-          opacity: 0.6
-        },
-        "& .MuiSlider-markLabel": {
-          color: style?.colors?.color,
-          ...style?.font,
-          whiteSpace: "pre"
-        },
-        "&.Mui-disabled": {
-          cursor: "not-allowed",
-          pointerEvents: "all !important"
-        }
+    <div
+      ref={ref}
+      style={{
+        width: "100%",
+        height: "100%",
+        paddingInline: horizontal ? "6px" : 0,
+        boxSizing: "border-box"
       }}
-    />
+    >
+      <Slider
+        value={inputValue}
+        disabled={readOnly || !enabled}
+        orientation={horizontal ? "horizontal" : "vertical"}
+        onChange={(_, newValue) => setInputValue(newValue as number)}
+        onChangeCommitted={(_, newValue) => onMouseUp(newValue as number)}
+        valueLabelDisplay="auto"
+        min={minimum}
+        max={maximum}
+        marks={marks}
+        step={increment}
+        sx={{
+          cursor: readOnly ? "not-allowed" : "default",
+          color: style?.colors?.color,
+          "& .MuiSlider-thumb": {
+            height: 16,
+            width: 16,
+            backgroundColor: "white",
+            border: "2px solid currentColor",
+            "&:focus, &:hover, &.Mui-active, &.Mui-focusVisible": {
+              boxShadow: "inherit"
+            }
+          },
+          "& .MuiSlider-valueLabelOpen": {
+            ...style?.colors,
+            ...style?.font,
+            opacity: 0.6
+          },
+          "& .MuiSlider-markLabel": {
+            color: style?.colors?.color,
+            ...style?.font,
+            whiteSpace: "pre"
+          },
+          "&.Mui-disabled": {
+            cursor: "not-allowed",
+            pointerEvents: "all !important"
+          }
+        }}
+      />
+    </div>
   );
 };
 

--- a/src/ui/widgets/Tabs/tabContainer.tsx
+++ b/src/ui/widgets/Tabs/tabContainer.tsx
@@ -15,7 +15,8 @@ import {
   ColorPropOpt,
   IntPropOpt,
   FontPropOpt,
-  ChildrenPropOpt
+  ChildrenPropOpt,
+  StringPropOpt
 } from "../propTypes";
 
 import { TabBar } from "./tabs";
@@ -25,6 +26,7 @@ import log from "loglevel";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 import { newColor } from "../../../types/color";
 import { useStyle } from "../../hooks/useStyle";
+import { parseToPixelInt } from "../utils";
 
 const widgetName = "tabcontainer";
 
@@ -36,7 +38,7 @@ export const TabContainerProps = {
   tabHeight: IntPropOpt,
   font: FontPropOpt,
   children: ChildrenPropOpt,
-  width: IntPropOpt,
+  width: StringPropOpt,
   height: IntPropOpt
 };
 
@@ -54,6 +56,10 @@ export const TabContainerComponent = (
   const tabChildren = useMemo(() => {
     return props.tabs.map((tab, idx) => {
       try {
+        const pixelWidth = parseToPixelInt(
+          width,
+          WIDGET_DEFAULT_SIZES["tabs"][0]
+        );
         return {
           name: tab.name,
           children: widgetDescriptionToComponent({
@@ -62,7 +68,7 @@ export const TabContainerComponent = (
             position: newRelativePosition(
               "0px",
               `${tabHeight}px`,
-              `${width}px`,
+              `${pixelWidth}px`,
               `${height - tabHeight}px`
             ),
             backgroundColor: newColor(colors?.backgroundColor as string),

--- a/src/ui/widgets/Tabs/tabContainer.tsx
+++ b/src/ui/widgets/Tabs/tabContainer.tsx
@@ -58,6 +58,7 @@ export const TabContainerComponent = (
           name: tab.name,
           children: widgetDescriptionToComponent({
             type: "display",
+            id: "123",
             position: newRelativePosition(
               "0px",
               `${tabHeight}px`,

--- a/src/ui/widgets/Thermometer/themometer.test.tsx
+++ b/src/ui/widgets/Thermometer/themometer.test.tsx
@@ -39,6 +39,10 @@ vi.mock("d3", () => {
   };
 });
 
+vi.mock("../../hooks/useMeasuredSize", () => ({
+  useMeasuredSize: () => [{ current: null }, { width: 60, height: 150 }]
+}));
+
 vi.mock("../../hooks/useStyle", () => ({
   useStyle: vi.fn(() => createMockStyle())
 }));
@@ -342,7 +346,7 @@ describe("Thermometer Component", () => {
           minimum={10}
           maximum={90}
           height={200}
-          width={50}
+          width={"50"}
           fillColor={ColorUtils.fromRgba(255, 0, 0, 1)}
           pvData={[{ ...pvDatum, value: mockValue }]}
         />

--- a/src/ui/widgets/Thermometer/thermometer.tsx
+++ b/src/ui/widgets/Thermometer/thermometer.tsx
@@ -8,12 +8,15 @@ import {
   FloatPropOpt,
   BoolPropOpt,
   InferWidgetProps,
-  ColorPropOpt
+  ColorPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { Box } from "@mui/material";
-import { getPvValueAndName } from "../utils";
+import { getPvValueAndName, parseToPixelInt } from "../utils";
 import { dTypeGetDoubleValue, DType } from "../../../types/dtypes";
 import { useStyle } from "../../hooks/useStyle";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize";
+import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const widgetName = "thermometer";
 
@@ -25,7 +28,7 @@ export const ThermometerComponentProps = {
   minimum: FloatPropOpt,
   maximum: FloatPropOpt,
   height: FloatPropOpt,
-  width: FloatPropOpt,
+  width: StringPropOpt,
   limitsFromPv: BoolPropOpt,
   fillColor: ColorPropOpt
 };
@@ -50,7 +53,12 @@ export const ThermometerComponent = (
   const svgRef = useRef<SVGSVGElement>(null);
   const style = useStyle({ foregroundColor: props.fillColor }, widgetName);
 
-  const { pvData, limitsFromPv = false, height = 160, width = 40 } = props;
+  const {
+    pvData,
+    limitsFromPv = false,
+    height = WIDGET_DEFAULT_SIZES[widgetName][1],
+    width = WIDGET_DEFAULT_SIZES[widgetName][0]
+  } = props;
   const { value } = getPvValueAndName(pvData);
 
   const colors = useMemo(
@@ -66,9 +74,14 @@ export const ThermometerComponent = (
     ]
   );
 
+  const [ref, size] = useMeasuredSize(
+    parseToPixelInt(width, WIDGET_DEFAULT_SIZES[widgetName][0]),
+    height
+  );
+
   const thermometerDimensions = useMemo(
-    () => calculateThermometerDimensions(width, height),
-    [width, height]
+    () => calculateThermometerDimensions(size.width, size.height),
+    [size]
   );
 
   let { minimum = 0, maximum = 100 } = props;
@@ -131,16 +144,21 @@ export const ThermometerComponent = (
       .attr("fill", colors.mercuryColor as string);
   }, [value, maximum, minimum, thermometerDimensions, colors]);
 
+  const remountKey = useMemo(() => {
+    if (!size.width || size.width < 10) return "thermo-init";
+    return `thermo-${Math.round(size.width)}`;
+  }, [size]);
+
   return (
     <Box
+      ref={ref}
       sx={{
         height: "100%",
         width: "100%",
-        position: "absolute",
         backgroundColor: "transparent"
       }}
     >
-      <svg ref={svgRef} />
+      <svg key={remountKey} ref={svgRef} />
     </Box>
   );
 };

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -10,12 +10,14 @@ import { BorderStyle, newBorder } from "../../types/border";
 
 export interface WidgetDescription {
   type: string;
+  id: string;
   // All other component properties
   [x: string]: any;
   children?: WidgetDescription[];
 }
 const ERROR_WIDGET: WidgetDescription = {
   type: "label",
+  id: `label_${crypto.randomUUID()}`,
   position: newRelativePosition(),
   font: newFont(16, FontStyle.Bold),
   backgroundColor: ColorUtils.TRANSPARENT,

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -3,6 +3,7 @@ import log from "loglevel";
 export { EmbeddedDisplay } from "./EmbeddedDisplay/embeddedDisplay";
 export { Label } from "./Label/label";
 export { Display } from "./Display/display";
+export { DisplayResponsive } from "./DisplayResponsive/displayResponsive";
 export { Shape } from "./Shape/shape";
 export { FlexContainer } from "./FlexContainer/flexContainer";
 export { DynamicPageWidget } from "./DynamicPage/dynamicPage";

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -21,6 +21,8 @@ export const StringArrayPropOpt = PropTypes.arrayOf(PropTypes.string);
 export const IntProp = PropTypes.number.isRequired;
 export const IntPropOpt = PropTypes.number;
 
+export const IntArrayPropOpt = PropTypes.arrayOf(PropTypes.number.isRequired);
+
 export const FloatProp = PropTypes.number.isRequired;
 export const FloatPropOpt = PropTypes.number;
 

--- a/src/ui/widgets/utils.test.ts
+++ b/src/ui/widgets/utils.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { parseCssPositionValue, parseToPixelInt } from "./utils";
+
+describe("parseCssPositionValue", () => {
+  const DEFAULT = 10;
+
+  it("returns px when value is a number", () => {
+    expect(parseCssPositionValue(20 as any, DEFAULT)).toEqual({
+      value: 20,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue(-5 as any, DEFAULT)).toEqual({
+      value: -5,
+      unit: "px"
+    });
+  });
+
+  it("returns default value when value is not a string or number", () => {
+    expect(parseCssPositionValue(null as any, DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue(undefined as any, DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue({} as any, DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+  });
+
+  it("parses numeric string and defaults unit to px", () => {
+    expect(parseCssPositionValue("100", DEFAULT)).toEqual({
+      value: 100,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue("  25  ", DEFAULT)).toEqual({
+      value: 25,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue("-5", DEFAULT)).toEqual({
+      value: -5,
+      unit: "px"
+    });
+  });
+
+  it("parses numeric string with css unit", () => {
+    expect(parseCssPositionValue("200px", DEFAULT)).toEqual({
+      value: 200,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue("50%", DEFAULT)).toEqual({
+      value: 50,
+      unit: "%"
+    });
+
+    expect(parseCssPositionValue("2.5rem", DEFAULT)).toEqual({
+      value: 2.5,
+      unit: "rem"
+    });
+
+    expect(parseCssPositionValue("1.25em", DEFAULT)).toEqual({
+      value: 1.25,
+      unit: "em"
+    });
+  });
+
+  it("returns default value for invalid css strings", () => {
+    expect(parseCssPositionValue("auto", DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue("calc(100%)", DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+
+    expect(parseCssPositionValue("px10", DEFAULT)).toEqual({
+      value: DEFAULT,
+      unit: "px"
+    });
+  });
+});
+
+describe("parseToPixelInt", () => {
+  const DEFAULT = 0;
+
+  it("returns the number unchanged when value is a number", () => {
+    expect(parseToPixelInt(10, DEFAULT)).toBe(10);
+    expect(parseToPixelInt(-5, DEFAULT)).toBe(-5);
+  });
+
+  it("parses numeric string", () => {
+    expect(parseToPixelInt("10", DEFAULT)).toBe(10);
+    expect(parseToPixelInt("  25  ", DEFAULT)).toBe(25);
+    expect(parseToPixelInt("-5", DEFAULT)).toBe(-5);
+  });
+
+  it("parses numeric string suffixed with px", () => {
+    expect(parseToPixelInt("10px", DEFAULT)).toBe(10);
+    expect(parseToPixelInt("-5px", DEFAULT)).toBe(-5);
+  });
+
+  it("returns default value for invalid strings", () => {
+    expect(parseToPixelInt("10%", DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt("10em", DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt("px10", DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt("10.5px", DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt("abc", DEFAULT)).toBe(DEFAULT);
+  });
+
+  it("returns default value for non-string and non-number values", () => {
+    expect(parseToPixelInt(null as any, DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt(undefined as any, DEFAULT)).toBe(DEFAULT);
+    expect(parseToPixelInt({} as any, DEFAULT)).toBe(DEFAULT);
+  });
+});

--- a/src/ui/widgets/utils.ts
+++ b/src/ui/widgets/utils.ts
@@ -67,6 +67,63 @@ export function trimFromString(value: string): number {
 }
 
 /**
+ * Parse a string in the form of 100px or 100% to extract the number and the unit.
+ * If ths fails return the default value and "px"
+ * @param value The value to parse
+ * @param defaultValue the default numeric value
+ * @returns the parsed value and units
+ */
+export const parseCssPositionValue = (
+  value: string | number,
+  defaultValue: number
+): { value: number; unit: string } => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { value, unit: "px" };
+  }
+
+  if (typeof value !== "string") {
+    return { value: defaultValue, unit: "px" };
+  }
+
+  const trimmed = value.trim();
+
+  // Match: number + optional unit
+  const match = trimmed.match(/^(-?\d+(?:\.\d+)?)([a-z%]+)?$/i);
+
+  if (!match) {
+    return { value: defaultValue, unit: "px" };
+  }
+
+  return {
+    value: Number(match[1]),
+    unit: match[2] ?? "px"
+  };
+};
+
+/**
+ * If a string is expected to take the form of either a integer or an integer suffixed with px
+ * return the string converted to a number, or the default value if the string cannot be converted
+ * @param value The string
+ * @param defaultValue The default value
+ * @returns The string converted to a Number or the default value
+ */
+export const parseToPixelInt = (
+  value: string | number,
+  defaultValue: number
+): number => {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return defaultValue;
+  }
+
+  const match = value.trim().match(/^(-?\d+)(px)?$/);
+  return match ? Number(match[1]) : defaultValue;
+};
+
+/**
  * Return the value of an optional parameter that may be undefined.
  * If it is undefined (i.e. not set) then return the default value
  * (defValue) provided in the input.

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -327,7 +327,7 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
   };
 
   return (
-    <>
+    <div id={`WidgetContainer_${props?.id ?? id}`}>
       {actionsPresent && contextOpen && (
         <ContextMenu
           actions={ruleProps.actions as WidgetActions}
@@ -341,6 +341,6 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
       />
-    </>
+    </div>
   );
 };

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -26,6 +26,7 @@ import { OPI_SIMPLE_PARSERS } from "./EmbeddedDisplay/opiParser";
 import { PositionPropNames, positionToCss } from "../../types/position";
 import { AlarmQuality, dTypeGetAlarm } from "../../types/dtypes";
 import { pvQualifiedName } from "../../types/pv";
+import { Box } from "@mui/material";
 
 const ALARM_SEVERITY_MAP = {
   [AlarmQuality.ALARM]: 1,
@@ -236,7 +237,8 @@ const DEFAULT_TOOLTIP = "${pvName}\n${pvValue}";
  * @returns JSX Element to render
  */
 export const Widget = (props: PVWidgetComponent): JSX.Element => {
-  const [id] = useId();
+  const [anId] = useId();
+  const id = props?.id ?? anId;
 
   const files = useContext(FileContext);
   const exitContext = useContext(ExitFileContext);
@@ -326,8 +328,10 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
     outlineOffset: showOutlines ? "-2px" : undefined
   };
 
+  const containerId = `WidgetContainer_${props?.id ?? id}`;
+
   return (
-    <div id={`WidgetContainer_${props?.id ?? id}`}>
+    <Box id={containerId} sx={{ width: "100%", height: "100%" }}>
       {actionsPresent && contextOpen && (
         <ContextMenu
           actions={ruleProps.actions as WidgetActions}
@@ -341,6 +345,6 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
       />
-    </div>
+    </Box>
   );
 };

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -18,6 +18,7 @@ import { File } from "../hooks/useFile";
 
 // Internal prop types object for properties which are not in a standard widget
 const BasicPropsType = {
+  id: StringPropOpt,
   rules: RulesPropOpt,
   scripts: ScriptsPropOpt,
   actions: ActionsPropType,


### PR DESCRIPTION
- Created a new hook useMeasuredSize that allows us to determine the pixel size of a component that has a non-pixel width. This helps resizing components with graphical elements.
- Allow widget width to be non-numeric, eg "100%"
- Fix a minor bug in pvwsToDType to ensure the max/min control range of the PV value is set.