### PR TITLE
Queue script execution requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.10",
+      "version": "0.10.11",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/ui/hooks/useScripts.ts
+++ b/src/ui/hooks/useScripts.ts
@@ -10,14 +10,12 @@ import {
 
 import { dTypeCoerceString, dTypeGetDoubleValue } from "../../types/dtypes";
 import { SubscriptionType } from "../../connection/plugin";
-import {
-  executeDynamicScriptInSandbox,
-  ScriptResponse
-} from "../widgets/EmbeddedDisplay/scripts/scriptExecutor";
+import { executeDynamicScriptInSandbox } from "../widgets/EmbeddedDisplay/scripts/scriptExecutor";
 import { Script } from "../../types/props";
 import { pvQualifiedName } from "../../types/pv";
 import { selectEnableDynamicScripts } from "../../redux/slices/configurationSlice";
 import { useEffect, useMemo } from "react";
+import { ScriptResponse } from "../widgets/EmbeddedDisplay/scripts/scriptTypes";
 
 export const useScripts = (
   scriptsProp: Script[],

--- a/src/ui/widgets/EmbeddedDisplay/scripts/scriptExecutor.ts
+++ b/src/ui/widgets/EmbeddedDisplay/scripts/scriptExecutor.ts
@@ -2,6 +2,9 @@ import log from "loglevel";
 import { v4 as uuidv4 } from "uuid";
 
 const parentOrigin = window.location.origin;
+
+// Sandboxed srcdoc iframe has an opaque origin, so postMessage events use event.origin === "null"
+// security is enforced by validating event.source against the known iframe.
 const SANDBOX_ORIGIN = "null";
 
 let iFrameSandboxScriptRunner: HTMLIFrameElement | null = null;
@@ -13,6 +16,15 @@ export interface ScriptResponse {
     [key: string]: any;
   };
 }
+
+type QueuedExecution = {
+  dynamicScriptCode: string;
+  pvs: { number: number | undefined; string: string | undefined }[];
+  resolve: (value: ScriptResponse) => void;
+  reject: (reason: any) => void;
+};
+
+const executionQueue: QueuedExecution[] = [];
 
 // Define the IFrame HTML and javascript to handle execution of dynamic scripts.
 // It also mocks/implements a small subset of the Phoebus script API sufficient for our PoC cases.
@@ -64,7 +76,7 @@ export const iFrameScriptExecutionHandlerCode = `
 
           try {
             const widget = {
-              props: {},
+              props: Object.create(null),
               setPropertyValue(key, value) {
                 this.props[key] = value;
               },
@@ -108,6 +120,7 @@ const buildSandboxIframe = async (): Promise<HTMLIFrameElement> => {
     }
 
     iFrameSandboxScriptRunner = document.createElement("iframe");
+    // Execution in a sandbox iframe is extremely important for security
     iFrameSandboxScriptRunner.setAttribute("sandbox", "allow-scripts");
     iFrameSandboxScriptRunner.style.width = "0";
     iFrameSandboxScriptRunner.style.height = "0";
@@ -149,6 +162,13 @@ const buildSandboxIframe = async (): Promise<HTMLIFrameElement> => {
         cleanup();
         log.debug("The script runner iframe has started");
         iFrameSandboxReady = true;
+
+        for (const item of executionQueue.splice(0)) {
+          postScriptToIframe(item.dynamicScriptCode, item.pvs)
+            .then(item.resolve)
+            .catch(item.reject);
+        }
+
         resolve(iFrameSandboxScriptRunner as HTMLIFrameElement);
       }
     };
@@ -161,41 +181,16 @@ const buildSandboxIframe = async (): Promise<HTMLIFrameElement> => {
   });
 };
 
-/***
- * A function that executes a Phoebos embedded script within a sandbox iFrame.
- * On first execution it will set the singleton iFrameScriptRunner variable.
- * On subsequent execution it will use the existing instance of iFrameScriptRunner
- * @param dynamicScriptCode the code to execute in the sandbox
- * @param pvs an array of PV values that are used by the script
- * @returns A dictionary that contains the return value of the function and a dictionary of the widget props that have been updated
- */
-export const executeDynamicScriptInSandbox = async (
+const postScriptToIframe = (
   dynamicScriptCode: string,
   pvs: { number: number | undefined; string: string | undefined }[]
 ): Promise<ScriptResponse> => {
-  if (!iFrameSandboxScriptRunner) {
-    await buildSandboxIframe();
-  }
-
-  if (!iFrameSandboxReady) {
-    // The iFrame sandbox is still starting up, this can happen on app startup.
-    // We don't want to block, so log and return an empty response.
-    log.warn(
-      "The Iframe sandbox is starting up, dynamic script execution skipped on this occasion."
-    );
-    return {
-      functionReturnValue: "",
-      widgetProps: {}
-    };
-  }
-
   if (!iFrameSandboxScriptRunner?.contentWindow) {
-    throw new Error("Iframe content window not available");
+    return Promise.reject(new Error("Iframe content window not available"));
   }
 
-  return new Promise<any>((resolve, reject) => {
+  return new Promise<ScriptResponse>((resolve, reject) => {
     const id = uuidv4();
-
     let hasTimedOut = false;
 
     const cleanup = () => {
@@ -210,17 +205,12 @@ export const executeDynamicScriptInSandbox = async (
 
     // Define a message handler to receive the responses from the IFrame.
     const messageHandler = (event: MessageEvent) => {
-      if (hasTimedOut) return;
-
-      if (event.origin !== SANDBOX_ORIGIN) {
-        return;
-      }
-
-      if (event.source !== iFrameSandboxScriptRunner?.contentWindow) {
-        return;
-      }
-
-      if (event.data?.id !== id) {
+      if (
+        hasTimedOut ||
+        event.origin !== SANDBOX_ORIGIN ||
+        event.source !== iFrameSandboxScriptRunner?.contentWindow ||
+        event.data?.id !== id
+      ) {
         return;
       }
 
@@ -230,24 +220,55 @@ export const executeDynamicScriptInSandbox = async (
       if (!event.data?.error) {
         // Success return the response data.
         resolve({
-          functionReturnValue: event.data?.functionReturnValue,
-          widgetProps: event.data?.widgetProps
+          functionReturnValue: event.data.functionReturnValue,
+          widgetProps: event.data.widgetProps
         });
       } else {
-        reject(event.data?.error);
+        reject(event.data.error);
       }
     };
 
     window.addEventListener("message", messageHandler);
 
-    // Send a message containing the script and pv values to the IFrame to trigger the execution of the script.
     iFrameSandboxScriptRunner?.contentWindow?.postMessage(
-      {
-        functionCode: dynamicScriptCode,
-        id,
-        pvs
-      },
+      { functionCode: dynamicScriptCode, id, pvs },
       "*"
     );
   });
+};
+
+/***
+ * A function that executes a Phoebos embedded script within a sandbox iFrame.
+ * On first execution it will set the singleton iFrameScriptRunner variable.
+ * On subsequent execution it will use the existing instance of iFrameScriptRunner.
+ * In the event that the iFrameScriptRunner is starting up,
+ * scripts are placed in a queue for later execution.
+ * @param dynamicScriptCode the code to execute in the sandbox
+ * @param pvs an array of PV values that are used by the script
+ * @returns A dictionary that contains the return value of the function and a dictionary of the widget props that have been updated
+ */
+export const executeDynamicScriptInSandbox = async (
+  dynamicScriptCode: string,
+  pvs: { number: number | undefined; string: string | undefined }[]
+): Promise<ScriptResponse> => {
+  if (!iFrameSandboxScriptRunner) {
+    buildSandboxIframe().catch(log.error);
+  }
+
+  if (!iFrameSandboxReady) {
+    return new Promise<ScriptResponse>((resolve, reject) => {
+      if (executionQueue.length < 200) {
+        executionQueue.push({
+          dynamicScriptCode,
+          pvs,
+          resolve,
+          reject
+        });
+      } else {
+        reject(new Error("Iframe script execution queue is full"));
+      }
+    });
+  }
+
+  return postScriptToIframe(dynamicScriptCode, pvs);
 };

--- a/src/ui/widgets/EmbeddedDisplay/scripts/scriptExecutor.ts
+++ b/src/ui/widgets/EmbeddedDisplay/scripts/scriptExecutor.ts
@@ -1,5 +1,7 @@
 import log from "loglevel";
 import { v4 as uuidv4 } from "uuid";
+import { ScriptResponse } from "./scriptTypes";
+import { enqueueScript, executeAllScriptsInQueue } from "./scriptQueue";
 
 const parentOrigin = window.location.origin;
 
@@ -9,22 +11,6 @@ const SANDBOX_ORIGIN = "null";
 
 let iFrameSandboxScriptRunner: HTMLIFrameElement | null = null;
 let iFrameSandboxReady = false;
-
-export interface ScriptResponse {
-  functionReturnValue: any;
-  widgetProps: {
-    [key: string]: any;
-  };
-}
-
-type QueuedExecution = {
-  dynamicScriptCode: string;
-  pvs: { number: number | undefined; string: string | undefined }[];
-  resolve: (value: ScriptResponse) => void;
-  reject: (reason: any) => void;
-};
-
-const executionQueue: QueuedExecution[] = [];
 
 // Define the IFrame HTML and javascript to handle execution of dynamic scripts.
 // It also mocks/implements a small subset of the Phoebus script API sufficient for our PoC cases.
@@ -163,11 +149,7 @@ const buildSandboxIframe = async (): Promise<HTMLIFrameElement> => {
         log.debug("The script runner iframe has started");
         iFrameSandboxReady = true;
 
-        for (const item of executionQueue.splice(0)) {
-          postScriptToIframe(item.dynamicScriptCode, item.pvs)
-            .then(item.resolve)
-            .catch(item.reject);
-        }
+        executeAllScriptsInQueue(postScriptToIframe);
 
         resolve(iFrameSandboxScriptRunner as HTMLIFrameElement);
       }
@@ -257,16 +239,7 @@ export const executeDynamicScriptInSandbox = async (
 
   if (!iFrameSandboxReady) {
     return new Promise<ScriptResponse>((resolve, reject) => {
-      if (executionQueue.length < 200) {
-        executionQueue.push({
-          dynamicScriptCode,
-          pvs,
-          resolve,
-          reject
-        });
-      } else {
-        reject(new Error("Iframe script execution queue is full"));
-      }
+      enqueueScript(dynamicScriptCode, pvs, resolve, reject);
     });
   }
 

--- a/src/ui/widgets/EmbeddedDisplay/scripts/scriptQueue.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/scripts/scriptQueue.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { enqueueScript, executeAllScriptsInQueue } from "./scriptQueue";
+
+import { ScriptResponse } from "./scriptTypes";
+
+const pvMock = [{ number: 1, string: "a" }];
+
+const flushPromises = async () => {
+  return new Promise(resolve => setTimeout(resolve, 0));
+};
+
+describe("script queue", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  test("adds item to queue when under limit", () => {
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    enqueueScript("code", pvMock, resolve, reject);
+
+    const execMock = vi.fn().mockResolvedValue({
+      functionReturnValue: 123,
+      widgetProps: {}
+    });
+
+    executeAllScriptsInQueue(execMock);
+
+    expect(execMock).toHaveBeenCalledWith("code", pvMock);
+  });
+
+  test("resolves queued items", async () => {
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    const response: ScriptResponse = {
+      functionReturnValue: 42,
+      widgetProps: { a: 1 }
+    };
+
+    enqueueScript("code", pvMock, resolve, reject);
+
+    const execMock = vi.fn().mockResolvedValue(response);
+
+    executeAllScriptsInQueue(execMock);
+
+    await flushPromises();
+
+    expect(resolve).toHaveBeenCalledWith(response);
+    expect(reject).not.toHaveBeenCalled();
+  });
+
+  test("rejects queued items when execution fails", async () => {
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    enqueueScript("code", pvMock, resolve, reject);
+
+    const execMock = vi.fn().mockRejectedValue(new Error("fail"));
+
+    executeAllScriptsInQueue(execMock);
+
+    await flushPromises();
+
+    expect(reject).toHaveBeenCalled();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  test("empties the queue after execution", () => {
+    const resolve = vi.fn();
+    const reject = vi.fn();
+
+    enqueueScript("code", pvMock, resolve, reject);
+
+    const execMock = vi.fn().mockResolvedValue({
+      functionReturnValue: 1,
+      widgetProps: {}
+    });
+
+    executeAllScriptsInQueue(execMock);
+    executeAllScriptsInQueue(execMock);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects when queue exceeds limit", () => {
+    for (let i = 0; i < 200; i++) {
+      enqueueScript("code", pvMock, vi.fn(), vi.fn());
+    }
+
+    const reject = vi.fn();
+    enqueueScript("overflow", pvMock, vi.fn(), reject);
+
+    expect(reject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("queue is full")
+      })
+    );
+  });
+});

--- a/src/ui/widgets/EmbeddedDisplay/scripts/scriptQueue.ts
+++ b/src/ui/widgets/EmbeddedDisplay/scripts/scriptQueue.ts
@@ -1,0 +1,46 @@
+import { QueuedExecution, ScriptResponse } from "./scriptTypes";
+
+const executionQueue: QueuedExecution[] = [];
+
+export const enqueueScript = (
+  dynamicScriptCode: string,
+  pvs: { number: number | undefined; string: string | undefined }[],
+  resolve: (value: ScriptResponse | PromiseLike<ScriptResponse>) => void,
+  reject: (reason?: any) => void
+) => {
+  if (typeof dynamicScriptCode !== "string") {
+    reject(new Error("Invalid script"));
+  }
+
+  if (executionQueue.length < 200) {
+    executionQueue.push({
+      dynamicScriptCode,
+      pvs,
+      resolve,
+      reject
+    });
+  } else {
+    reject(new Error("Iframe script execution queue is full"));
+  }
+};
+
+export const executeAllScriptsInQueue = (
+  executeScriptAsync: (
+    dynamicScriptCode: string,
+    pvs: { number: number | undefined; string: string | undefined }[]
+  ) => Promise<ScriptResponse>
+) => {
+  for (const item of executionQueue.splice(0)) {
+    executeScriptAsync(item.dynamicScriptCode, item.pvs)
+      .then(res => {
+        try {
+          item.resolve(res);
+        } catch {}
+      })
+      .catch(err => {
+        try {
+          item.reject(err);
+        } catch {}
+      });
+  }
+};

--- a/src/ui/widgets/EmbeddedDisplay/scripts/scriptTypes.ts
+++ b/src/ui/widgets/EmbeddedDisplay/scripts/scriptTypes.ts
@@ -1,0 +1,13 @@
+export interface ScriptResponse {
+  functionReturnValue: any;
+  widgetProps: {
+    [key: string]: any;
+  };
+}
+
+export type QueuedExecution = {
+  dynamicScriptCode: string;
+  pvs: { number: number | undefined; string: string | undefined }[];
+  resolve: (value: ScriptResponse) => void;
+  reject: (reason: any) => void;
+};

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -27,7 +27,7 @@ import { executeAction, WidgetAction, WidgetActions } from "./widgetActions";
 import { Popover } from "react-tiny-popover";
 import { resolveTooltip } from "./tooltip";
 import { useScripts } from "../hooks/useScripts";
-import { ScriptResponse } from "./EmbeddedDisplay/scripts/scriptExecutor";
+import { ScriptResponse } from "./EmbeddedDisplay/scripts/scriptTypes";
 import { OPI_SIMPLE_PARSERS } from "./EmbeddedDisplay/opiParser";
 import { PositionPropNames, positionToCss } from "../../types/position";
 import { AlarmQuality, dTypeGetAlarm } from "../../types/dtypes";


### PR DESCRIPTION
This resolves the bug "When the synoptic is first loaded, pv dependent objects such as beamlines do not obey their scripts until the page is reloaded" https://jira.diamond.ac.uk/browse/EU-304

Now while the IFrame is starting up, scripts are put on a queue for execution once the IFrame is ready. This ensures that the scripts triggered at start up are executed.