### PR TITLE
Support for the display of an mjpg image stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.11",
+      "version": "0.10.12",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",
@@ -131,13 +131,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -220,14 +220,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -356,29 +356,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -528,13 +528,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1277,15 +1277,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1966,33 +1967,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2000,9 +2001,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/connection/serviceConnection.test.ts
+++ b/src/connection/serviceConnection.test.ts
@@ -48,7 +48,7 @@ const config: CsWebLibConfig = {
   PVWS_SSL: true,
   storeMode: "DEV",
   THROTTLE_PERIOD: 100,
-  mjpgStreamEndPoint: "",
+  defaultMjpgEndpoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }

--- a/src/connection/serviceConnection.test.ts
+++ b/src/connection/serviceConnection.test.ts
@@ -48,6 +48,7 @@ const config: CsWebLibConfig = {
   PVWS_SSL: true,
   storeMode: "DEV",
   THROTTLE_PERIOD: 100,
+  mjpgStreamEndPoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }

--- a/src/redux/connectionMiddleware.test.ts
+++ b/src/redux/connectionMiddleware.test.ts
@@ -33,7 +33,7 @@ const config: CsWebLibConfig = {
   PVWS_SSL: true,
   storeMode: "DEV",
   THROTTLE_PERIOD: 100,
-  mjpgStreamEndPoint: "",
+  defaultMjpgEndpoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }

--- a/src/redux/connectionMiddleware.test.ts
+++ b/src/redux/connectionMiddleware.test.ts
@@ -33,6 +33,7 @@ const config: CsWebLibConfig = {
   PVWS_SSL: true,
   storeMode: "DEV",
   THROTTLE_PERIOD: 100,
+  mjpgStreamEndPoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }

--- a/src/redux/csWebLibConfig.ts
+++ b/src/redux/csWebLibConfig.ts
@@ -7,6 +7,6 @@ export type CsWebLibConfig = {
   PVWS_SOCKET: string | undefined;
   PVWS_SSL: boolean | undefined;
   THROTTLE_PERIOD: number | undefined;
-  mjpgStreamEndPoint: string | undefined;
+  defaultMjpgEndpoint: string | undefined;
   csWebLibFeatureFlags: FeatureFlags;
 };

--- a/src/redux/csWebLibConfig.ts
+++ b/src/redux/csWebLibConfig.ts
@@ -7,5 +7,6 @@ export type CsWebLibConfig = {
   PVWS_SOCKET: string | undefined;
   PVWS_SSL: boolean | undefined;
   THROTTLE_PERIOD: number | undefined;
+  mjpgStreamEndPoint: string | undefined;
   csWebLibFeatureFlags: FeatureFlags;
 };

--- a/src/redux/slices/configurationSlice.test.ts
+++ b/src/redux/slices/configurationSlice.test.ts
@@ -13,7 +13,7 @@ describe("configurationSlice", () => {
     PVWS_SOCKET: "",
     PVWS_SSL: true,
     THROTTLE_PERIOD: 100,
-    mjpgStreamEndPoint: "",
+    defaultMjpgEndpoint: "",
     csWebLibFeatureFlags: {
       enableDynamicScripts: false
     }

--- a/src/redux/slices/configurationSlice.test.ts
+++ b/src/redux/slices/configurationSlice.test.ts
@@ -13,6 +13,7 @@ describe("configurationSlice", () => {
     PVWS_SOCKET: "",
     PVWS_SSL: true,
     THROTTLE_PERIOD: 100,
+    mjpgStreamEndPoint: "",
     csWebLibFeatureFlags: {
       enableDynamicScripts: false
     }

--- a/src/redux/slices/configurationSlice.ts
+++ b/src/redux/slices/configurationSlice.ts
@@ -41,5 +41,5 @@ export const {
   selectConfiguration,
   selectFeatureFlags,
   selectEnableDynamicScripts,
-  selectDefaultMjpgEndpoint,
+  selectDefaultMjpgEndpoint
 } = configurationSlice.selectors;

--- a/src/redux/slices/configurationSlice.ts
+++ b/src/redux/slices/configurationSlice.ts
@@ -10,6 +10,7 @@ const initialState: CsWebLibConfig = {
   PVWS_SOCKET: "",
   PVWS_SSL: true,
   THROTTLE_PERIOD: 100,
+  mjpgStreamEndPoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }
@@ -29,7 +30,8 @@ export const configurationSlice = createSlice({
     selectConfiguration: state => state,
     selectFeatureFlags: state => state.csWebLibFeatureFlags,
     selectEnableDynamicScripts: state =>
-      state.csWebLibFeatureFlags?.enableDynamicScripts ?? false
+      state.csWebLibFeatureFlags?.enableDynamicScripts ?? false,
+    selectMjpgStreamEndPoint: state => state.mjpgStreamEndPoint
   }
 });
 
@@ -38,5 +40,6 @@ export default configurationSlice.reducer;
 export const {
   selectConfiguration,
   selectFeatureFlags,
-  selectEnableDynamicScripts
+  selectEnableDynamicScripts,
+  selectMjpgStreamEndPoint
 } = configurationSlice.selectors;

--- a/src/redux/slices/configurationSlice.ts
+++ b/src/redux/slices/configurationSlice.ts
@@ -10,7 +10,7 @@ const initialState: CsWebLibConfig = {
   PVWS_SOCKET: "",
   PVWS_SSL: true,
   THROTTLE_PERIOD: 100,
-  mjpgStreamEndPoint: "",
+  defaultMjpgEndpoint: "",
   csWebLibFeatureFlags: {
     enableDynamicScripts: false
   }
@@ -31,7 +31,7 @@ export const configurationSlice = createSlice({
     selectFeatureFlags: state => state.csWebLibFeatureFlags,
     selectEnableDynamicScripts: state =>
       state.csWebLibFeatureFlags?.enableDynamicScripts ?? false,
-    selectMjpgStreamEndPoint: state => state.mjpgStreamEndPoint
+    selectDefaultMjpgEndpoint: state => state.defaultMjpgEndpoint
   }
 });
 
@@ -41,5 +41,5 @@ export const {
   selectConfiguration,
   selectFeatureFlags,
   selectEnableDynamicScripts,
-  selectMjpgStreamEndPoint
+  selectDefaultMjpgEndpoint,
 } = configurationSlice.selectors;

--- a/src/ui/hooks/useConnection.ts
+++ b/src/ui/hooks/useConnection.ts
@@ -48,41 +48,22 @@ export function useConnection(
 export const useConnectionMultiplePv = (
   id: string,
   pvNames: string[],
-  subscriptionType?: SubscriptionType,
-  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
-    pvNameSubscriptions: string[];
-    additionalPvData: PvArrayResults;
-  }
+  subscriptionType?: SubscriptionType
 ) => {
-  let pvNameArray = pvNames.filter(x => !!x);
+  const pvNameArray = pvNames.filter(x => !!x);
   const typeArray = !subscriptionType ? [] : [subscriptionType];
 
-  let additionalPvData: PvArrayResults = {};
-
-  let pvNameSubscriptions = pvNameArray;
-  if (overridePvSubscriptionsCallback) {
-    // This provides a mechanism for widgets to override the standard pv subscription
-    ({ pvNameSubscriptions, additionalPvData } =
-      overridePvSubscriptionsCallback(pvNameArray));
-    pvNameArray = [
-      ...new Set([...pvNameArray, ...Object.keys(additionalPvData)])
-    ];
-  }
-
-  useSubscription(id, pvNameSubscriptions, typeArray);
+  useSubscription(id, pvNameArray, typeArray);
   const pvStates = useSelector(
-    (state: CsState): PvArrayResults =>
-      selectPvStates(state, pvNameSubscriptions),
+    (state: CsState): PvArrayResults => selectPvStates(state, pvNameArray),
     pvStateComparator
   );
 
-  const pvResults = { ...pvStates, ...additionalPvData };
-
   return {
     pvData: pvNameArray
-      .filter(pvName => pvName in pvResults)
+      .filter(pvName => pvName in pvStates)
       .map(pvName => {
-        const [pvState, effPvName] = pvResults[pvName];
+        const [pvState, effPvName] = pvStates[pvName];
 
         return {
           effectivePvName: effPvName,

--- a/src/ui/hooks/useConnection.ts
+++ b/src/ui/hooks/useConnection.ts
@@ -3,7 +3,6 @@ import { useSubscription } from "./useSubscription";
 import { useSelector } from "react-redux";
 import {
   CsState,
-  PvDataCollection,
   selectPvStates,
   pvStateComparator,
   PvArrayResults
@@ -49,28 +48,45 @@ export function useConnection(
 export const useConnectionMultiplePv = (
   id: string,
   pvNames: string[],
-  type?: SubscriptionType
-): PvDataCollection => {
+  subscriptionType?: SubscriptionType,
+  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
+    pvNameSubscriptions: string[];
+    additionalPvData: PvArrayResults;
+  }
+) => {
   const pvNameArray = pvNames.filter(x => !!x);
-  const typeArray = !type ? [] : [type];
+  const typeArray = !subscriptionType ? [] : [subscriptionType];
 
-  useSubscription(id, pvNameArray, typeArray);
+  let additionalPvData: PvArrayResults = {};
 
-  const pvResults = useSelector(
-    (state: CsState): PvArrayResults => selectPvStates(state, pvNameArray),
+  let pvNameSubscriptions = pvNameArray;
+  if (overridePvSubscriptionsCallback) {
+    // This provides a mechanism for widgets to override the standard pv subscription
+    ({ pvNameSubscriptions, additionalPvData } =
+      overridePvSubscriptionsCallback(pvNameArray));
+  }
+
+  useSubscription(id, pvNameSubscriptions, typeArray);
+  const pvStates = useSelector(
+    (state: CsState): PvArrayResults =>
+      selectPvStates(state, pvNameSubscriptions),
     pvStateComparator
   );
 
-  return {
-    pvData: pvNameArray.map(pvName => {
-      const [pvState, effPvName] = pvResults[pvName];
+  const pvResults = { ...pvStates, ...additionalPvData };
 
-      return {
-        effectivePvName: effPvName,
-        connected: pvState?.connected ?? false,
-        readonly: pvState?.readonly ?? false,
-        value: pvState?.value
-      };
-    })
+  return {
+    pvData: pvNameArray
+      .filter(pvName => pvName in pvResults)
+      .map(pvName => {
+        const [pvState, effPvName] = pvResults[pvName];
+
+        return {
+          effectivePvName: effPvName,
+          connected: pvState?.connected ?? false,
+          readonly: pvState?.readonly ?? false,
+          value: pvState?.value
+        };
+      })
   };
 };

--- a/src/ui/hooks/useConnection.ts
+++ b/src/ui/hooks/useConnection.ts
@@ -3,6 +3,7 @@ import { useSubscription } from "./useSubscription";
 import { useSelector } from "react-redux";
 import {
   CsState,
+  PvDataCollection,
   selectPvStates,
   pvStateComparator,
   PvArrayResults
@@ -48,29 +49,28 @@ export function useConnection(
 export const useConnectionMultiplePv = (
   id: string,
   pvNames: string[],
-  subscriptionType?: SubscriptionType
-) => {
+  type?: SubscriptionType
+): PvDataCollection => {
   const pvNameArray = pvNames.filter(x => !!x);
-  const typeArray = !subscriptionType ? [] : [subscriptionType];
+  const typeArray = !type ? [] : [type];
 
   useSubscription(id, pvNameArray, typeArray);
-  const pvStates = useSelector(
+
+  const pvResults = useSelector(
     (state: CsState): PvArrayResults => selectPvStates(state, pvNameArray),
     pvStateComparator
   );
 
   return {
-    pvData: pvNameArray
-      .filter(pvName => pvName in pvStates)
-      .map(pvName => {
-        const [pvState, effPvName] = pvStates[pvName];
+    pvData: pvNameArray.map(pvName => {
+      const [pvState, effPvName] = pvResults[pvName];
 
-        return {
-          effectivePvName: effPvName,
-          connected: pvState?.connected ?? false,
-          readonly: pvState?.readonly ?? false,
-          value: pvState?.value
-        };
-      })
+      return {
+        effectivePvName: effPvName,
+        connected: pvState?.connected ?? false,
+        readonly: pvState?.readonly ?? false,
+        value: pvState?.value
+      };
+    })
   };
 };

--- a/src/ui/hooks/useConnection.ts
+++ b/src/ui/hooks/useConnection.ts
@@ -54,7 +54,7 @@ export const useConnectionMultiplePv = (
     additionalPvData: PvArrayResults;
   }
 ) => {
-  const pvNameArray = pvNames.filter(x => !!x);
+  let pvNameArray = pvNames.filter(x => !!x);
   const typeArray = !subscriptionType ? [] : [subscriptionType];
 
   let additionalPvData: PvArrayResults = {};
@@ -64,6 +64,9 @@ export const useConnectionMultiplePv = (
     // This provides a mechanism for widgets to override the standard pv subscription
     ({ pvNameSubscriptions, additionalPvData } =
       overridePvSubscriptionsCallback(pvNameArray));
+    pvNameArray = [
+      ...new Set([...pvNameArray, ...Object.keys(additionalPvData)])
+    ];
   }
 
   useSubscription(id, pvNameSubscriptions, typeArray);

--- a/src/ui/widgets/DynamicImage/demoImage.test.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.test.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import {
-  DemoImageComponent,
-  overridePvSubscriptionsWithMjpgUrl
-} from "./demoImage";
+import { DemoImageComponent, buildMjpgPvUrls } from "./demoImage";
 import { newColor } from "../../../types/color";
 import { vi } from "vitest";
 import { createMockStyle } from "../../../test-utils/styleTestUtils";
@@ -30,14 +27,14 @@ vi.mock("../utils", () => ({
 }));
 
 describe("DemoImageComponent", () => {
+  beforeEach(() => {
+    showWarningMock.mockClear();
+  });
+
   it("renders an img with the expected src and alt text", () => {
     const data = [
       {
-        value: newDType(
-          { stringValue: "/images/demoCameraImage.jpg" },
-          DAlarmNONE()
-        ),
-        effectivePvName: "demoImage"
+        value: newDType({ stringValue: "An ignored value" }, DAlarmNONE())
       } as PvDatum
     ];
 
@@ -45,13 +42,19 @@ describe("DemoImageComponent", () => {
       <DemoImageComponent
         macros={{}}
         pvData={data}
+        mjpgEndpoints={["http://www.images.diamond.ac.uk/abc"]}
         backgroundColor={newColor("#123456")}
       />
     );
 
-    const img = screen.getByRole("img", { name: /PvName: TEST:PV/i });
+    const img = screen.getByRole("img", {
+      name: /PvName: TEST:PV/i
+    });
     expect(img).toBeInTheDocument();
-    expect(img).toHaveAttribute("src", "/images/demoCameraImage.jpg");
+    expect(img).toHaveAttribute(
+      "src",
+      "http://www.images.diamond.ac.uk/abc/TEST:PV"
+    );
     expect(img).toHaveAttribute("alt", "PvName: TEST:PV");
   });
 
@@ -64,39 +67,81 @@ describe("DemoImageComponent", () => {
     );
   });
 
-  it("falls back to next src on error", () => {
+  it("cycles through URLs sequentially on repeated errors", () => {
     const data = [
-      { value: newDType({ stringValue: "bad-url-1" }) },
-      { value: newDType({ stringValue: "good-url-2" }) }
+      { value: newDType({ stringValue: "ignored" }, DAlarmNONE()) } as PvDatum
     ];
 
-    render(<DemoImageComponent pvData={data as any} macros={{}} />);
+    render(
+      <DemoImageComponent
+        macros={{}}
+        pvData={data}
+        mjpgEndpoints={["http://a", "http://b", "http://c"]}
+      />
+    );
 
     const img = screen.getByRole("img");
 
-    // initial src
-    expect(img).toHaveAttribute("src", "bad-url-1");
+    expect(img).toHaveAttribute("src", "http://a/TEST:PV");
 
-    // trigger error → should fallback
     fireEvent.error(img);
+    expect(img).toHaveAttribute("src", "http://b/TEST:PV");
 
-    expect(img).toHaveAttribute("src", "good-url-2");
+    fireEvent.error(img);
+    expect(img).toHaveAttribute("src", "http://c/TEST:PV");
   });
 
-  it("calls showWarning when all sources fail", () => {
+  it("shows warning when all URLs fail", () => {
     const data = [
-      { value: { stringValue: "bad-url-1" } },
-      { value: { stringValue: "bad-url-2" } }
+      { value: newDType({ stringValue: "ignored" }, DAlarmNONE()) } as PvDatum
     ];
 
-    render(<DemoImageComponent pvData={data as any} macros={{}} />);
+    render(
+      <DemoImageComponent
+        macros={{}}
+        pvData={data}
+        mjpgEndpoints={["http://a", "http://b"]}
+      />
+    );
 
     const img = screen.getByRole("img");
 
-    // first failure → fallback
+    fireEvent.error(img); // move to second URL
+    fireEvent.error(img); // no more URLs → warning
+
+    expect(showWarningMock).toHaveBeenCalledWith(
+      "Could not load mjpg image stream for the PV: TEST:PV"
+    );
+  });
+
+  it("resets failure counter after exhausting URLs", () => {
+    const data = [
+      { value: newDType({ stringValue: "ignored" }, DAlarmNONE()) } as PvDatum
+    ];
+
+    render(
+      <DemoImageComponent
+        macros={{}}
+        pvData={data}
+        mjpgEndpoints={["http://a", "http://b"]}
+      />
+    );
+
+    const img = screen.getByRole("img");
+
+    fireEvent.error(img); // → b
+    fireEvent.error(img); // → warning + reset
+
+    // Trigger again → should start sequence again from second URL
     fireEvent.error(img);
 
-    // second failure → warning
+    expect(img).toHaveAttribute("src", "http://b/TEST:PV");
+  });
+
+  it("handles missing endpoints without crashing", () => {
+    render(<DemoImageComponent macros={{}} pvData={[]} mjpgEndpoints={[]} />);
+
+    const img = screen.getByRole("img");
     fireEvent.error(img);
 
     expect(showWarningMock).toHaveBeenCalledWith(
@@ -105,82 +150,52 @@ describe("DemoImageComponent", () => {
   });
 });
 
-describe("overridePvSubscriptionsWithMjpgUrl", () => {
-  it("returns empty subscriptions and no additional data when no inputs provided", () => {
-    const fn = overridePvSubscriptionsWithMjpgUrl(undefined);
-
-    const result = fn([]);
-
-    expect(result.pvNameSubscriptions).toEqual([]);
-    expect(result.additionalPvData).toEqual({});
+describe("buildMjpgPvUrls", () => {
+  it("returns empty array if pvName is missing", () => {
+    const result = buildMjpgPvUrls(["http://test"], "");
+    expect(result).toEqual([]);
   });
 
-  it("returns empty additionalPvData when pvNameArray is empty", () => {
-    const fn = overridePvSubscriptionsWithMjpgUrl(["http://camera"]);
-
-    const result = fn([]);
-
-    expect(result.pvNameSubscriptions).toEqual([]);
-    expect(result.additionalPvData).toEqual({});
+  it("returns empty array if endpoints are undefined", () => {
+    const result = buildMjpgPvUrls(undefined, "TEST:PV");
+    expect(result).toEqual([]);
   });
 
-  it("creates pv entries for each valid endpoint", () => {
-    const endpoints = ["http://cam1", "http://cam2"];
-    const fn = overridePvSubscriptionsWithMjpgUrl(endpoints);
-
-    const result = fn(["TEST:ARRAY"]);
-
-    expect(result.pvNameSubscriptions).toEqual([]);
-
-    const keys = Object.keys(result.additionalPvData);
-    expect(keys).toHaveLength(2);
-
-    expect(keys).toContain("TEST:OUTPUT_0");
-    expect(keys).toContain("TEST:OUTPUT_1");
-
-    const entry = result.additionalPvData["TEST:OUTPUT_0"];
-    expect(entry[0].value?.value.stringValue).toBe("http://cam1/TEST:OUTPUT");
-    expect(entry[0].value?.alarm).toEqual(DAlarmNONE());
+  it("returns empty array if endpoints are empty", () => {
+    const result = buildMjpgPvUrls([], "TEST:PV");
+    expect(result).toEqual([]);
   });
 
-  it("removes pva:// prefix and replaces :ARRAY with :OUTPUT", () => {
-    const fn = overridePvSubscriptionsWithMjpgUrl(["http://cam"]);
+  it("filters out null/undefined endpoints", () => {
+    const result = buildMjpgPvUrls(
+      ["http://a", null, undefined, "http://b"],
+      "TEST:PV"
+    );
 
-    const result = fn(["pva://MY:PV:ARRAY"]);
-
-    const entry = result.additionalPvData["MY:PV:OUTPUT_0"];
-
-    expect(entry[0].value?.value.stringValue).toBe("http://cam/MY:PV:OUTPUT");
+    expect(result).toEqual(["http://a/TEST:PV", "http://b/TEST:PV"]);
   });
 
-  it("filters out null and undefined endpoints", () => {
-    const fn = overridePvSubscriptionsWithMjpgUrl([
-      "http://cam1",
-      null,
-      undefined,
-      "http://cam2"
-    ]);
+  it("removes pva:// prefix from pvName", () => {
+    const result = buildMjpgPvUrls(["http://a"], "pva://TEST:PV");
 
-    const result = fn(["TEST:ARRAY"]);
-
-    const keys = Object.keys(result.additionalPvData);
-    expect(keys).toHaveLength(2);
-
-    expect(
-      result?.additionalPvData?.["TEST:OUTPUT_0"]?.[0]?.value?.value.stringValue
-    ).toBe("http://cam1/TEST:OUTPUT");
-
-    expect(
-      result.additionalPvData["TEST:OUTPUT_1"][0].value?.value.stringValue
-    ).toBe("http://cam2/TEST:OUTPUT");
+    expect(result).toEqual(["http://a/TEST:PV"]);
   });
 
-  it("returns empty additionalPvData if all endpoints are null/undefined", () => {
-    const fn = overridePvSubscriptionsWithMjpgUrl([null, undefined]);
+  it("replaces :ARRAY suffix with :OUTPUT", () => {
+    const result = buildMjpgPvUrls(["http://a"], "TEST:PV:ARRAY");
 
-    const result = fn(["TEST:ARRAY"]);
+    expect(result).toEqual(["http://a/TEST:PV:OUTPUT"]);
+  });
 
-    expect(result.additionalPvData).toEqual({});
-    expect(result.pvNameSubscriptions).toEqual([]);
+  it("handles both prefix removal and suffix replacement together", () => {
+    const result = buildMjpgPvUrls(["http://a"], "pva://TEST:PV:ARRAY");
+
+    expect(result).toEqual(["http://a/TEST:PV:OUTPUT"]);
+  });
+
+  it("builds urls for multiple endpoints", () => {
+    const result = buildMjpgPvUrls(["http://a", "http://b"], "TEST:PV");
+
+    expect(result).toEqual(["http://a/TEST:PV", "http://b/TEST:PV"]);
   });
 });

--- a/src/ui/widgets/DynamicImage/demoImage.test.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.test.tsx
@@ -12,7 +12,11 @@ vi.mock("../../hooks/useStyle", () => ({
 describe("DemoImageComponent", () => {
   it("renders an img with the expected src and alt text", () => {
     render(
-      <DemoImageComponent macros={{}} backgroundColor={newColor("#123456")} />
+      <DemoImageComponent
+        macros={{}}
+        pvData={[]}
+        backgroundColor={newColor("#123456")}
+      />
     );
 
     const img = screen.getByRole("img", { name: /Static demo image/i });
@@ -22,7 +26,7 @@ describe("DemoImageComponent", () => {
   });
 
   it("handles undefined backgroundColor gracefully (no style set)", () => {
-    render((<DemoImageComponent macros={{}} />) as any);
+    render((<DemoImageComponent pvData={[]} macros={{}} />) as any);
 
     const img = screen.getByRole("img", { name: /Static demo image/i });
     expect((img as HTMLElement).getAttribute("style") || "").not.toMatch(

--- a/src/ui/widgets/DynamicImage/demoImage.test.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.test.tsx
@@ -1,36 +1,186 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { DemoImageComponent } from "./demoImage";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  DemoImageComponent,
+  overridePvSubscriptionsWithMjpgUrl
+} from "./demoImage";
 import { newColor } from "../../../types/color";
 import { vi } from "vitest";
 import { createMockStyle } from "../../../test-utils/styleTestUtils";
+import { PvDatum } from "../../../redux/csState";
+import { DAlarmNONE, newDType } from "../../../types/dtypes";
 
 vi.mock("../../hooks/useStyle", () => ({
   useStyle: vi.fn(() => createMockStyle())
 }));
 
+const showWarningMock = vi.fn();
+
+vi.mock("../../hooks", () => ({
+  useNotification: () => ({
+    showWarning: showWarningMock
+  })
+}));
+
+vi.mock("../utils", () => ({
+  getPvValueAndName: (pvData: any[], index = 0) => ({
+    value: pvData[index]?.value,
+    effectivePvName: "TEST:PV"
+  })
+}));
+
 describe("DemoImageComponent", () => {
   it("renders an img with the expected src and alt text", () => {
+    const data = [
+      {
+        value: newDType(
+          { stringValue: "/images/demoCameraImage.jpg" },
+          DAlarmNONE()
+        ),
+        effectivePvName: "demoImage"
+      } as PvDatum
+    ];
+
     render(
       <DemoImageComponent
         macros={{}}
-        pvData={[]}
+        pvData={data}
         backgroundColor={newColor("#123456")}
       />
     );
 
-    const img = screen.getByRole("img", { name: /Static demo image/i });
+    const img = screen.getByRole("img", { name: /PvName: TEST:PV/i });
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute("src", "/images/demoCameraImage.jpg");
-    expect(img).toHaveAttribute("alt", "Static demo image");
+    expect(img).toHaveAttribute("alt", "PvName: TEST:PV");
   });
 
   it("handles undefined backgroundColor gracefully (no style set)", () => {
     render((<DemoImageComponent pvData={[]} macros={{}} />) as any);
 
-    const img = screen.getByRole("img", { name: /Static demo image/i });
+    const img = screen.getByRole("img", { name: /PvName: TEST:PV/i });
     expect((img as HTMLElement).getAttribute("style") || "").not.toMatch(
       /background-color/i
     );
+  });
+
+  it("falls back to next src on error", () => {
+    const data = [
+      { value: newDType({ stringValue: "bad-url-1" }) },
+      { value: newDType({ stringValue: "good-url-2" }) }
+    ];
+
+    render(<DemoImageComponent pvData={data as any} macros={{}} />);
+
+    const img = screen.getByRole("img");
+
+    // initial src
+    expect(img).toHaveAttribute("src", "bad-url-1");
+
+    // trigger error → should fallback
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute("src", "good-url-2");
+  });
+
+  it("calls showWarning when all sources fail", () => {
+    const data = [
+      { value: { stringValue: "bad-url-1" } },
+      { value: { stringValue: "bad-url-2" } }
+    ];
+
+    render(<DemoImageComponent pvData={data as any} macros={{}} />);
+
+    const img = screen.getByRole("img");
+
+    // first failure → fallback
+    fireEvent.error(img);
+
+    // second failure → warning
+    fireEvent.error(img);
+
+    expect(showWarningMock).toHaveBeenCalledWith(
+      "Could not load mjpg image stream for the PV: TEST:PV"
+    );
+  });
+});
+
+describe("overridePvSubscriptionsWithMjpgUrl", () => {
+  it("returns empty subscriptions and no additional data when no inputs provided", () => {
+    const fn = overridePvSubscriptionsWithMjpgUrl(undefined);
+
+    const result = fn([]);
+
+    expect(result.pvNameSubscriptions).toEqual([]);
+    expect(result.additionalPvData).toEqual({});
+  });
+
+  it("returns empty additionalPvData when pvNameArray is empty", () => {
+    const fn = overridePvSubscriptionsWithMjpgUrl(["http://camera"]);
+
+    const result = fn([]);
+
+    expect(result.pvNameSubscriptions).toEqual([]);
+    expect(result.additionalPvData).toEqual({});
+  });
+
+  it("creates pv entries for each valid endpoint", () => {
+    const endpoints = ["http://cam1", "http://cam2"];
+    const fn = overridePvSubscriptionsWithMjpgUrl(endpoints);
+
+    const result = fn(["TEST:ARRAY"]);
+
+    expect(result.pvNameSubscriptions).toEqual([]);
+
+    const keys = Object.keys(result.additionalPvData);
+    expect(keys).toHaveLength(2);
+
+    expect(keys).toContain("TEST:OUTPUT_0");
+    expect(keys).toContain("TEST:OUTPUT_1");
+
+    const entry = result.additionalPvData["TEST:OUTPUT_0"];
+    expect(entry[0].value?.value.stringValue).toBe("http://cam1/TEST:OUTPUT");
+    expect(entry[0].value?.alarm).toEqual(DAlarmNONE());
+  });
+
+  it("removes pva:// prefix and replaces :ARRAY with :OUTPUT", () => {
+    const fn = overridePvSubscriptionsWithMjpgUrl(["http://cam"]);
+
+    const result = fn(["pva://MY:PV:ARRAY"]);
+
+    const entry = result.additionalPvData["MY:PV:OUTPUT_0"];
+
+    expect(entry[0].value?.value.stringValue).toBe("http://cam/MY:PV:OUTPUT");
+  });
+
+  it("filters out null and undefined endpoints", () => {
+    const fn = overridePvSubscriptionsWithMjpgUrl([
+      "http://cam1",
+      null,
+      undefined,
+      "http://cam2"
+    ]);
+
+    const result = fn(["TEST:ARRAY"]);
+
+    const keys = Object.keys(result.additionalPvData);
+    expect(keys).toHaveLength(2);
+
+    expect(
+      result?.additionalPvData?.["TEST:OUTPUT_0"]?.[0]?.value?.value.stringValue
+    ).toBe("http://cam1/TEST:OUTPUT");
+
+    expect(
+      result.additionalPvData["TEST:OUTPUT_1"][0].value?.value.stringValue
+    ).toBe("http://cam2/TEST:OUTPUT");
+  });
+
+  it("returns empty additionalPvData if all endpoints are null/undefined", () => {
+    const fn = overridePvSubscriptionsWithMjpgUrl([null, undefined]);
+
+    const result = fn(["TEST:ARRAY"]);
+
+    expect(result.additionalPvData).toEqual({});
+    expect(result.pvNameSubscriptions).toEqual([]);
   });
 });

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Widget } from "../widget";
 import { PVComponent, PVWidgetPropType } from "../widgetProps";
 import { InferWidgetProps, MacrosPropOpt, ColorPropOpt } from "../propTypes";
@@ -7,6 +7,8 @@ import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
 import { PvArrayResults, PvState } from "../../../redux/csState";
 import { getPvValueAndName } from "../utils";
+import { DAlarmNONE, newDType } from "../../../types/dtypes";
+import { useNotification } from "../../hooks";
 
 const widgetName = "demoImage";
 
@@ -19,15 +21,32 @@ export const DemoImageComponent = (
   props: InferWidgetProps<typeof DemoImageProps> & PVComponent
 ): JSX.Element => {
   const { colors } = useStyle(props, widgetName);
-  const { value } = getPvValueAndName(props?.pvData);
-  const imageFileName =
-    value?.value?.stringValue ?? "/images/demoCameraImage.jpg";
+  const { value, effectivePvName } = getPvValueAndName(props?.pvData);
+
+  const [src, setSrc] = useState(value?.value?.stringValue);
+  const [numberOfFailures, setNumberOfFailures] = useState(0);
+  const { showWarning } = useNotification();
+
+  const handleError = () => {
+    if (numberOfFailures < (props?.pvData?.length ?? 0) - 1) {
+      const { value } = getPvValueAndName(props?.pvData, numberOfFailures + 1);
+      setSrc(value?.value?.stringValue);
+      setNumberOfFailures(numberOfFailures + 1);
+    } else {
+      // reset in case of re-render
+      setNumberOfFailures(0);
+      showWarning(
+        `Could not load mjpg image stream for the PV: ${effectivePvName}`
+      );
+    }
+  };
 
   return (
     <Box
       component="img"
-      src={imageFileName}
-      alt={"Static demo image"}
+      src={src}
+      alt={`PvName: ${effectivePvName}`}
+      onError={handleError}
       sx={{
         width: "100%",
         height: "100%",
@@ -39,35 +58,42 @@ export const DemoImageComponent = (
   );
 };
 
-const overridePvSubscriptionsCallback =
-  (mjpgEndpoint?: string) =>
+export const overridePvSubscriptionsWithMjpgUrl =
+  (mjpgEndpoints?: (string | null | undefined)[]) =>
   (
     pvNameArray: string[]
   ): { pvNameSubscriptions: string[]; additionalPvData: PvArrayResults } => {
-    const additionalPvData: PvArrayResults = {};
+    let additionalPvData: PvArrayResults = {};
 
-    if (pvNameArray.length > 0 && mjpgEndpoint) {
+    if (pvNameArray.length > 0 && mjpgEndpoints && mjpgEndpoints.length > 0) {
       // remove leading pva protocol string and replace :ARRAY with :OUTPUT
       const trimmedPvName = pvNameArray[0]
         .replace(/^pva:\/\//, "")
         .replace(/:ARRAY$/, ":OUTPUT");
 
-      // Create a pv data value that contains the link to the mjpg
-      additionalPvData[pvNameArray[0]] = [
-        {
-          value: {
-            value: { stringValue: `${mjpgEndpoint}/${trimmedPvName}` },
-            display: {},
-            partial: false
-          },
-          connected: true,
-          readonly: true
-        } as PvState,
-        pvNameArray[0]
-      ];
+      // Create a dictionary of pv data values that contain the url of the mjpg,
+      // typically one primary, one fallback url
+      additionalPvData = mjpgEndpoints
+        ?.filter(x => x != null)
+        ?.map(
+          (endpoint, i) =>
+            [
+              {
+                value: newDType(
+                  { stringValue: `${endpoint}/${trimmedPvName}` },
+                  DAlarmNONE()
+                )
+              } as PvState,
+              trimmedPvName
+            ] as [PvState, string]
+        )
+        ?.reduce((acc, val, i) => {
+          acc[`${val[1]}_${i}`] = val;
+          return acc;
+        }, additionalPvData);
     }
 
-    // don't subscribe to other pvs via PVWS.
+    // don't subscribe to any other pvs via PVWS.
     const pvNameSubscriptions: string[] = [];
     return { pvNameSubscriptions, additionalPvData };
   };
@@ -80,13 +106,13 @@ const DemoImageWidgetProps = {
 export const DemoImage = (
   props: InferWidgetProps<typeof DemoImageWidgetProps>
 ): JSX.Element => (
-    <Widget
-      baseWidget={DemoImageComponent}
-      {...props}
-      overridePvSubscriptionsCallback={overridePvSubscriptionsCallback(
-        props?.defaultMjpgEndpoint
-      )}
-    />
-  );
+  <Widget
+    baseWidget={DemoImageComponent}
+    {...props}
+    overridePvSubscriptionsCallback={overridePvSubscriptionsWithMjpgUrl(
+      props?.mjpgEndpoints
+    )}
+  />
+);
 
 registerWidget(DemoImage, DemoImageWidgetProps, widgetName);

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import { Widget } from "../widget";
-import { WidgetPropType } from "../widgetProps";
+import { PVComponent, PVWidgetPropType } from "../widgetProps";
 import { InferWidgetProps, MacrosPropOpt, ColorPropOpt } from "../propTypes";
 import { registerWidget } from "../register";
 import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
+import { PvArrayResults, PvState } from "../../../redux/csState";
+import { useSelector } from "react-redux";
+import { selectMjpgStreamEndPoint } from "../../../redux/slices/configurationSlice";
+import { getPvValueAndName } from "../utils";
 
 const widgetName = "demoImage";
 
@@ -14,11 +18,12 @@ const DemoImageProps = {
 };
 
 export const DemoImageComponent = (
-  props: InferWidgetProps<typeof DemoImageProps>
+  props: InferWidgetProps<typeof DemoImageProps> & PVComponent
 ): JSX.Element => {
   const { colors } = useStyle(props, widgetName);
-  // this image needs to be exist in the Daedalus public/images folder
-  const imageFileName = "/images/demoCameraImage.jpg";
+  const { value } = getPvValueAndName(props?.pvData);
+  const imageFileName =
+    value?.value?.stringValue ?? "/images/demoCameraImage.jpg";
 
   return (
     <Box
@@ -36,13 +41,58 @@ export const DemoImageComponent = (
   );
 };
 
+const overridePvSubscriptionsCallback =
+  (mjpgEndpoint?: string) =>
+  (
+    pvNameArray: string[]
+  ): { pvNameSubscriptions: string[]; additionalPvData: PvArrayResults } => {
+    const additionalPvData: PvArrayResults = {};
+
+    if (pvNameArray.length > 0 && mjpgEndpoint) {
+      // remove leading pva protocol string and replace :ARRAY with :OUTPUT
+      const trimmedPvName = pvNameArray[0]
+        .replace(/^pva:\/\//, "")
+        .replace(/:ARRAY$/, ":OUTPUT");
+
+      // Create a pv data value that contains the link to the mjpg
+      additionalPvData[pvNameArray[0]] = [
+        {
+          value: {
+            value: { stringValue: `${mjpgEndpoint}/${trimmedPvName}` },
+            display: {},
+            partial: false
+          },
+          connected: true,
+          readonly: true
+        } as PvState,
+        pvNameArray[0]
+      ];
+    }
+
+    // don't subscribe to other pvs via PVWS.
+    const pvNameSubscriptions: string[] = [];
+    return { pvNameSubscriptions, additionalPvData };
+  };
+
 const DemoImageWidgetProps = {
   ...DemoImageProps,
-  ...WidgetPropType
+  ...PVWidgetPropType
 };
 
 export const DemoImage = (
   props: InferWidgetProps<typeof DemoImageWidgetProps>
-): JSX.Element => <Widget baseWidget={DemoImageComponent} {...props} />;
+): JSX.Element => {
+  const mjpgEndpoint = useSelector(selectMjpgStreamEndPoint);
+
+  return (
+    <Widget
+      baseWidget={DemoImageComponent}
+      {...props}
+      overridePvSubscriptionsCallback={overridePvSubscriptionsCallback(
+        mjpgEndpoint
+      )}
+    />
+  );
+};
 
 registerWidget(DemoImage, DemoImageWidgetProps, widgetName);

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -6,8 +6,6 @@ import { registerWidget } from "../register";
 import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
 import { PvArrayResults, PvState } from "../../../redux/csState";
-import { useSelector } from "react-redux";
-import { selectMjpgStreamEndPoint } from "../../../redux/slices/configurationSlice";
 import { getPvValueAndName } from "../utils";
 
 const widgetName = "demoImage";
@@ -81,18 +79,14 @@ const DemoImageWidgetProps = {
 
 export const DemoImage = (
   props: InferWidgetProps<typeof DemoImageWidgetProps>
-): JSX.Element => {
-  const mjpgEndpoint = useSelector(selectMjpgStreamEndPoint);
-
-  return (
+): JSX.Element => (
     <Widget
       baseWidget={DemoImageComponent}
       {...props}
       overridePvSubscriptionsCallback={overridePvSubscriptionsCallback(
-        mjpgEndpoint
+        props?.defaultMjpgEndpoint
       )}
     />
   );
-};
 
 registerWidget(DemoImage, DemoImageWidgetProps, widgetName);

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -1,37 +1,41 @@
 import React, { useState } from "react";
 import { Widget } from "../widget";
 import { PVComponent, PVWidgetPropType } from "../widgetProps";
-import { InferWidgetProps, MacrosPropOpt, ColorPropOpt } from "../propTypes";
+import {
+  InferWidgetProps,
+  MacrosPropOpt,
+  ColorPropOpt,
+  StringArrayPropOpt
+} from "../propTypes";
 import { registerWidget } from "../register";
 import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
-import { PvArrayResults, PvState } from "../../../redux/csState";
 import { getPvValueAndName } from "../utils";
-import { DAlarmNONE, newDType } from "../../../types/dtypes";
 import { useNotification } from "../../hooks";
 
 const widgetName = "demoImage";
 
 const DemoImageProps = {
   macros: MacrosPropOpt,
-  backgroundColor: ColorPropOpt
+  backgroundColor: ColorPropOpt,
+  mjpgEndpoints: StringArrayPropOpt
 };
 
 export const DemoImageComponent = (
   props: InferWidgetProps<typeof DemoImageProps> & PVComponent
 ): JSX.Element => {
   const { colors } = useStyle(props, widgetName);
-  const { value, effectivePvName } = getPvValueAndName(props?.pvData);
+  const { effectivePvName } = getPvValueAndName(props?.pvData);
+  const urls = buildMjpgPvUrls(props?.mjpgEndpoints, effectivePvName);
 
-  const [src, setSrc] = useState(value?.value?.stringValue);
+  const [src, setSrc] = useState(urls?.[0]);
   const [numberOfFailures, setNumberOfFailures] = useState(0);
   const { showWarning } = useNotification();
 
   const handleError = () => {
-    if (numberOfFailures < (props?.pvData?.length ?? 0) - 1) {
-      const { value } = getPvValueAndName(props?.pvData, numberOfFailures + 1);
-      setSrc(value?.value?.stringValue);
-      setNumberOfFailures(numberOfFailures + 1);
+    if (numberOfFailures + 1 < (urls?.length ?? 0)) {
+      setSrc(urls?.[numberOfFailures + 1]);
+      setNumberOfFailures(prev => prev + 1);
     } else {
       // reset in case of re-render
       setNumberOfFailures(0);
@@ -58,45 +62,24 @@ export const DemoImageComponent = (
   );
 };
 
-export const overridePvSubscriptionsWithMjpgUrl =
-  (mjpgEndpoints?: (string | null | undefined)[]) =>
-  (
-    pvNameArray: string[]
-  ): { pvNameSubscriptions: string[]; additionalPvData: PvArrayResults } => {
-    let additionalPvData: PvArrayResults = {};
+export const buildMjpgPvUrls = (
+  mjpgEndpoints: (string | null | undefined)[] | undefined,
+  pvName: string
+): string[] => {
+  if (!pvName || !mjpgEndpoints || mjpgEndpoints?.length === 0) {
+    return [];
+  }
 
-    if (pvNameArray.length > 0 && mjpgEndpoints && mjpgEndpoints.length > 0) {
-      // remove leading pva protocol string and replace :ARRAY with :OUTPUT
-      const trimmedPvName = pvNameArray[0]
-        .replace(/^pva:\/\//, "")
-        .replace(/:ARRAY$/, ":OUTPUT");
+  const trimmedPvName = pvName
+    .replace(/^pva:\/\//, "")
+    .replace(/:ARRAY$/, ":OUTPUT");
 
-      // Create a dictionary of pv data values that contain the url of the mjpg,
-      // typically one primary, one fallback url
-      additionalPvData = mjpgEndpoints
-        ?.filter(x => x != null)
-        ?.map(
-          (endpoint, i) =>
-            [
-              {
-                value: newDType(
-                  { stringValue: `${endpoint}/${trimmedPvName}` },
-                  DAlarmNONE()
-                )
-              } as PvState,
-              trimmedPvName
-            ] as [PvState, string]
-        )
-        ?.reduce((acc, val, i) => {
-          acc[`${val[1]}_${i}`] = val;
-          return acc;
-        }, additionalPvData);
-    }
+  const additionalPvData = mjpgEndpoints
+    ?.filter(x => x != null)
+    ?.map((endpoint, i) => `${endpoint}/${trimmedPvName}`);
 
-    // don't subscribe to any other pvs via PVWS.
-    const pvNameSubscriptions: string[] = [];
-    return { pvNameSubscriptions, additionalPvData };
-  };
+  return additionalPvData ?? [];
+};
 
 const DemoImageWidgetProps = {
   ...DemoImageProps,
@@ -105,14 +88,6 @@ const DemoImageWidgetProps = {
 
 export const DemoImage = (
   props: InferWidgetProps<typeof DemoImageWidgetProps>
-): JSX.Element => (
-  <Widget
-    baseWidget={DemoImageComponent}
-    {...props}
-    overridePvSubscriptionsCallback={overridePvSubscriptionsWithMjpgUrl(
-      props?.mjpgEndpoints
-    )}
-  />
-);
+): JSX.Element => <Widget baseWidget={DemoImageComponent} {...props} />;
 
 registerWidget(DemoImage, DemoImageWidgetProps, widgetName);

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -90,7 +90,9 @@ export const DynamicPageComponent = (
             scalingOrigin={"0 0"}
             scroll={props.scroll ?? false}
             theme={theme}
-            mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint]}
+            mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint].filter(
+              x => x != null
+            )}
           />
           <div
             style={{

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -17,7 +17,8 @@ import {
   StringProp,
   InferWidgetProps,
   BorderPropOpt,
-  BoolPropOpt
+  BoolPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import {
   EmbeddedDisplay,
@@ -36,7 +37,8 @@ const DynamicPageProps = {
   location: StringProp,
   border: BorderPropOpt,
   showCloseButton: BoolPropOpt,
-  scroll: BoolPropOpt
+  scroll: BoolPropOpt,
+  mjpgEndpoint: StringPropOpt
 };
 
 // Generic display widget to put other things inside
@@ -88,7 +90,7 @@ export const DynamicPageComponent = (
             scalingOrigin={"0 0"}
             scroll={props.scroll ?? false}
             theme={theme}
-            defaultMjpgEndpoint={defaultMjpgEndpoint}
+            mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint]}
           />
           <div
             style={{
@@ -136,7 +138,9 @@ export const DynamicPageComponent = (
             scalingOrigin={"0 0"}
             scroll={props.scroll ?? false}
             theme={theme}
-            defaultMjpgEndpoint={defaultMjpgEndpoint}
+            mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint].filter(
+              x => x != null
+            )}
           />
         </div>
       </ExitFileContext.Provider>

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -27,6 +27,8 @@ import { newColor } from "../../../types/color";
 import { newRelativePosition } from "../../../types/position";
 import { ExitFileContext, FileContext } from "../../../misc/fileContext";
 import { phoebusTheme } from "../../../phoebusTheme";
+import { useSelector } from "react-redux";
+import { selectDefaultMjpgEndpoint } from "../../../redux/slices/configurationSlice";
 
 const widgetName = "dynamicpage";
 
@@ -47,7 +49,7 @@ export const DynamicPageComponent = (
 
   const file = fileContext.pageState[props.location];
 
-  // Default behaviour is to show close button
+  // Default behavior is to show close button
   const showCloseButton =
     props.showCloseButton === undefined ? true : props.showCloseButton;
 
@@ -57,6 +59,8 @@ export const DynamicPageComponent = (
     ...style.font,
     ...style.other
   };
+
+  const defaultMjpgEndpoint = useSelector(selectDefaultMjpgEndpoint);
 
   if (file === undefined) {
     return (
@@ -84,6 +88,7 @@ export const DynamicPageComponent = (
             scalingOrigin={"0 0"}
             scroll={props.scroll ?? false}
             theme={theme}
+            defaultMjpgEndpoint={defaultMjpgEndpoint}
           />
           <div
             style={{
@@ -131,6 +136,7 @@ export const DynamicPageComponent = (
             scalingOrigin={"0 0"}
             scroll={props.scroll ?? false}
             theme={theme}
+            defaultMjpgEndpoint={defaultMjpgEndpoint}
           />
         </div>
       </ExitFileContext.Provider>

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -249,21 +249,25 @@ export const EmbeddedDisplay = (
 
   let component: JSX.Element;
   try {
-    component = widgetDescriptionToComponent({
-      type: "display",
-      id: `display_${crypto.randomUUID()}`,
-      position: resolvedProps.position,
-      backgroundColor:
-        selectedDescription.backgroundColor ?? newColor("rgb(255,255,255"),
-      border:
-        resolvedProps.border ??
-        newBorder(BorderStyle.Line, newColor("white"), 0),
-      overflow: overflow,
-      children: [selectedDescription],
-      scaling: [scaleFactorX, scaleFactorY],
-      autoZoomToFit: applyAutoZoomToFit,
-      scalingOrigin: resolvedProps.scalingOrigin
-    }, undefined, props?.defaultMjpgEndpoint);
+    component = widgetDescriptionToComponent(
+      {
+        type: "display",
+        id: `display_${crypto.randomUUID()}`,
+        position: resolvedProps.position,
+        backgroundColor:
+          selectedDescription.backgroundColor ?? newColor("rgb(255,255,255"),
+        border:
+          resolvedProps.border ??
+          newBorder(BorderStyle.Line, newColor("white"), 0),
+        overflow: overflow,
+        children: [selectedDescription],
+        scaling: [scaleFactorX, scaleFactorY],
+        autoZoomToFit: applyAutoZoomToFit,
+        scalingOrigin: resolvedProps.scalingOrigin
+      },
+      undefined,
+      props?.mjpgEndpoints
+    );
   } catch (e) {
     const message = `Error loading ${(resolvedProps.file as File)?.path}: ${e}.`;
     log.warn(message);

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -263,7 +263,7 @@ export const EmbeddedDisplay = (
       scaling: [scaleFactorX, scaleFactorY],
       autoZoomToFit: applyAutoZoomToFit,
       scalingOrigin: resolvedProps.scalingOrigin
-    });
+    }, undefined, props?.defaultMjpgEndpoint);
   } catch (e) {
     const message = `Error loading ${(resolvedProps.file as File)?.path}: ${e}.`;
     log.warn(message);

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -55,7 +55,7 @@ export function widgetDescriptionToComponent(
   // from the component dictionary provided. Uses recursion to generate children.
   widgetDescription: WidgetDescription,
   listIndex?: number,
-  defaultMjpgEndpoint?: string
+  mjpgEndpoints?: (string | undefined | null)[]
 ): JSX.Element {
   const { type, children = [], ...otherProps } = widgetDescription;
 
@@ -99,7 +99,8 @@ export function widgetDescriptionToComponent(
 
   // Create all children components - recursive
   const ChildComponents = children.map(
-    (child, index): JSX.Element => widgetDescriptionToComponent(child, index)
+    (child, index): JSX.Element =>
+      widgetDescriptionToComponent(child, index, mjpgEndpoints)
   );
   // Return the node with children as children
   return (
@@ -108,7 +109,7 @@ export function widgetDescriptionToComponent(
       key={listIndex}
       position={widgetDescription.position}
       {...otherProps}
-      defaultMjpgEndpoint={defaultMjpgEndpoint}
+      mjpgEndpoints={mjpgEndpoints}
     >
       {ChildComponents}
     </Component>

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -54,7 +54,8 @@ export function widgetDescriptionToComponent(
   // Converts a JS object matching a position description into React component
   // from the component dictionary provided. Uses recursion to generate children.
   widgetDescription: WidgetDescription,
-  listIndex?: number
+  listIndex?: number,
+  defaultMjpgEndpoint?: string
 ): JSX.Element {
   const { type, children = [], ...otherProps } = widgetDescription;
 
@@ -107,6 +108,7 @@ export function widgetDescriptionToComponent(
       key={listIndex}
       position={widgetDescription.position}
       {...otherProps}
+      defaultMjpgEndpoint={defaultMjpgEndpoint}
     >
       {ChildComponents}
     </Component>

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -33,6 +33,7 @@ import { PositionPropNames, positionToCss } from "../../types/position";
 import { AlarmQuality, dTypeGetAlarm } from "../../types/dtypes";
 import { pvQualifiedName } from "../../types/pv";
 import { Box } from "@mui/material";
+import { PvArrayResults } from "../../redux/csState";
 
 const ALARM_SEVERITY_MAP = {
   [AlarmQuality.ALARM]: 1,
@@ -113,6 +114,10 @@ export const ConnectingComponent = (props: {
   widgetProps: ConnectingComponentWidgetProps;
   containerStyle: CSSProperties;
   onContextMenu?: (e: React.MouseEvent) => void;
+  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
+    pvNameSubscriptions: string[];
+    additionalPvData: PvArrayResults;
+  };
 }): JSX.Element => {
   const Component = props.component;
   const { id, alarmBorder = false, pvMetadataList } = props.widgetProps;
@@ -158,7 +163,9 @@ export const ConnectingComponent = (props: {
 
   const { pvData } = useConnectionMultiplePv(
     id,
-    pvNames.map(x => pvQualifiedName(x))
+    pvNames.map(x => pvQualifiedName(x)),
+    undefined,
+    props?.overridePvSubscriptionsCallback
   );
 
   let border = props.widgetProps.border;
@@ -329,7 +336,12 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
   log.debug(ruleProps);
 
   // Extract remaining parameters
-  const { baseWidget, position, ...baseWidgetProps } = {
+  const {
+    baseWidget,
+    overridePvSubscriptionsCallback,
+    position,
+    ...baseWidgetProps
+  } = {
     ...ruleProps,
     ...scriptProps,
     position: ruleProps.position
@@ -364,6 +376,7 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         widgetProps={baseWidgetProps as ConnectingComponentWidgetProps}
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
+        overridePvSubscriptionsCallback={overridePvSubscriptionsCallback}
       />
     </Box>
   );

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -33,7 +33,6 @@ import { PositionPropNames, positionToCss } from "../../types/position";
 import { AlarmQuality, dTypeGetAlarm } from "../../types/dtypes";
 import { pvQualifiedName } from "../../types/pv";
 import { Box } from "@mui/material";
-import { PvArrayResults } from "../../redux/csState";
 
 const ALARM_SEVERITY_MAP = {
   [AlarmQuality.ALARM]: 1,
@@ -114,10 +113,6 @@ export const ConnectingComponent = (props: {
   widgetProps: ConnectingComponentWidgetProps;
   containerStyle: CSSProperties;
   onContextMenu?: (e: React.MouseEvent) => void;
-  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
-    pvNameSubscriptions: string[];
-    additionalPvData: PvArrayResults;
-  };
 }): JSX.Element => {
   const Component = props.component;
   const { id, alarmBorder = false, pvMetadataList } = props.widgetProps;
@@ -164,8 +159,7 @@ export const ConnectingComponent = (props: {
   const { pvData } = useConnectionMultiplePv(
     id,
     pvNames.map(x => pvQualifiedName(x)),
-    undefined,
-    props?.overridePvSubscriptionsCallback
+    undefined
   );
 
   let border = props.widgetProps.border;
@@ -336,12 +330,7 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
   log.debug(ruleProps);
 
   // Extract remaining parameters
-  const {
-    baseWidget,
-    overridePvSubscriptionsCallback,
-    position,
-    ...baseWidgetProps
-  } = {
+  const { baseWidget, position, ...baseWidgetProps } = {
     ...ruleProps,
     ...scriptProps,
     position: ruleProps.position
@@ -376,7 +365,6 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         widgetProps={baseWidgetProps as ConnectingComponentWidgetProps}
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
-        overridePvSubscriptionsCallback={overridePvSubscriptionsCallback}
       />
     </Box>
   );

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -24,7 +24,8 @@ const BasicPropsType = {
   actions: ActionsPropType,
   tooltip: StringPropOpt,
   border: BorderPropOpt,
-  visible: BoolPropOpt
+  visible: BoolPropOpt,
+  defaultMjpgEndpoint: StringPropOpt
 };
 
 const PositionPropsType = {

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -1,4 +1,4 @@
-import { PvDataCollection } from "../../redux/csState";
+import { PvArrayResults, PvDataCollection } from "../../redux/csState";
 import {
   StringPropOpt,
   BoolPropOpt,
@@ -59,7 +59,13 @@ type AnyOtherProps = {
   [x: string]: GenericProp;
 };
 
-type BaseWidgetProps = { baseWidget: React.FC<any> };
+type BaseWidgetProps = {
+  baseWidget: React.FC<any>;
+  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
+    pvNameSubscriptions: string[];
+    additionalPvData: PvArrayResults;
+  };
+};
 
 type ComponentProps = {
   style?: Record<string, string>;

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -9,7 +9,8 @@ import {
   RulesPropOpt,
   PvTypePropOpt,
   PVMetadataType,
-  ScriptsPropOpt
+  ScriptsPropOpt,
+  StringArrayPropOpt
 } from "./propTypes";
 
 import { GenericProp } from "../../types/props";
@@ -25,7 +26,7 @@ const BasicPropsType = {
   tooltip: StringPropOpt,
   border: BorderPropOpt,
   visible: BoolPropOpt,
-  defaultMjpgEndpoint: StringPropOpt
+  mjpgEndpoints: StringArrayPropOpt
 };
 
 const PositionPropsType = {

--- a/src/ui/widgets/widgetProps.ts
+++ b/src/ui/widgets/widgetProps.ts
@@ -1,4 +1,4 @@
-import { PvArrayResults, PvDataCollection } from "../../redux/csState";
+import { PvDataCollection } from "../../redux/csState";
 import {
   StringPropOpt,
   BoolPropOpt,
@@ -63,10 +63,6 @@ type AnyOtherProps = {
 
 type BaseWidgetProps = {
   baseWidget: React.FC<any>;
-  overridePvSubscriptionsCallback?: (pvNameArray: string[]) => {
-    pvNameSubscriptions: string[];
-    additionalPvData: PvArrayResults;
-  };
 };
 
 type ComponentProps = {


### PR DESCRIPTION
This PR:
- Allows the DemoImage widget to use a mjpg image stream by passing in the urls of the servers to the widget via the props.
- A default mjpg endpoint is defined in the configuration and used in the DynamicPage widget
- A primary mjpg endpoint can be passed to the DynamicPage widget
