### PR TITLE
Fix sizing when there are many absolute positioned elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.12",
+      "version": "0.10.13",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -133,18 +133,16 @@ export const DynamicPageComponent = (
       <ExitFileContext.Provider
         value={() => fileContext.removePage(props.location)}
       >
-        <div style={fullStyle}>
-          <EmbeddedDisplay
-            file={file}
-            position={newRelativePosition()}
-            scalingOrigin={"0 0"}
-            scroll={props.scroll ?? false}
-            theme={theme}
-            mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint].filter(
-              x => x != null
-            )}
-          />
-        </div>
+        <EmbeddedDisplay
+          file={file}
+          position={newRelativePosition(undefined, undefined, "100%", "100%")}
+          scalingOrigin={"0 0"}
+          scroll={props.scroll ?? false}
+          theme={theme}
+          mjpgEndpoints={[props?.mjpgEndpoint, defaultMjpgEndpoint].filter(
+            x => x != null
+          )}
+        />
       </ExitFileContext.Provider>
     );
   }

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.test.tsx
@@ -271,8 +271,7 @@ describe("<EmbeddedDisplay>", (): void => {
     const display = container.querySelector(".display");
     expect(display).not.toBeNull();
 
-    const innerDisplayWidgetWrapper =
-      display?.firstElementChild?.firstElementChild;
+    const innerDisplayWidgetWrapper = display?.firstElementChild;
 
     expect(innerDisplayWidgetWrapper).toHaveStyle("position: absolute");
 
@@ -285,7 +284,7 @@ describe("<EmbeddedDisplay>", (): void => {
 
     const displayInner = display?.querySelector(".display");
     expect(displayInner).not.toBeNull();
-    const groupBoxWidgetWrapper = displayInner?.firstChild?.firstChild;
+    const groupBoxWidgetWrapper = displayInner?.firstChild;
     expect(groupBoxWidgetWrapper).toHaveStyle("position: absolute");
     expect(groupBoxWidgetWrapper).toHaveStyle("height: 250px");
     expect(groupBoxWidgetWrapper).toHaveStyle("width: 240px");

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -32,7 +32,6 @@ import { OPI_SIMPLE_PARSERS } from "./EmbeddedDisplay/opiParser";
 import { PositionPropNames, positionToCss } from "../../types/position";
 import { AlarmQuality, dTypeGetAlarm } from "../../types/dtypes";
 import { pvQualifiedName } from "../../types/pv";
-import { Box } from "@mui/material";
 
 const ALARM_SEVERITY_MAP = {
   [AlarmQuality.ALARM]: 1,
@@ -210,6 +209,7 @@ export const ConnectingComponent = (props: {
         onMouseDown={mouseDown}
         onMouseUp={mouseUp}
         style={props.containerStyle}
+        data-testid="ConnectingComponent-clickable-div-wrapper"
       >
         {component}
       </div>
@@ -349,10 +349,8 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
     outlineOffset: showOutlines ? "-2px" : undefined
   };
 
-  const containerId = `WidgetContainer_${props?.id ?? id}`;
-
   return (
-    <Box id={containerId} sx={{ width: "100%", height: "100%" }}>
+    <>
       {actionsPresent && contextOpen && (
         <ContextMenu
           actions={ruleProps.actions as WidgetActions}
@@ -366,6 +364,6 @@ export const Widget = (props: PVWidgetComponent): JSX.Element => {
         containerStyle={containerStyle}
         onContextMenu={onContextMenu}
       />
-    </Box>
+    </>
   );
 };


### PR DESCRIPTION
- Replaced the `<Box id={containerId} sx={{ width: "100%", height: "100%" }}>` container in the widget component with a fragment `<>`. The box was causing multiple relative divs to be placed in the layout - causing lots of empty scroll space.
- Removed the `<div style={fullStyle}>` container from DynamicPage, which now allows embedded display styles to fill the page.
