### PR TITLE
Parse Image props

### DIFF
--- a/src/types/axis.test.ts
+++ b/src/types/axis.test.ts
@@ -1,5 +1,5 @@
 import { newColor } from "./color";
-import { Axis } from "./axis";
+import { newAxis } from "./axis";
 import { FontStyle, newFont } from "./font";
 
 describe("Axis", () => {
@@ -18,17 +18,16 @@ describe("Axis", () => {
       onRight: true,
       xAxis: true
     };
-    const axis = new Axis(testValues);
+    const axis = newAxis(testValues);
 
     expect({ ...axis, color: axis.color.colorString }).toEqual({
       ...testValues,
       color: testValues.color.colorString
     });
-    expect(axis).toBeInstanceOf(Axis);
   });
 
   it("constructs the y axis with only defaults", (): void => {
-    const axis = new Axis({ xAxis: false });
+    const axis = newAxis({ xAxis: false });
 
     expect({ ...axis, color: axis.color.colorString }).toEqual({
       color: newColor("rgb(0, 0, 0)").colorString,
@@ -44,6 +43,5 @@ describe("Axis", () => {
       onRight: false,
       xAxis: false
     });
-    expect(axis).toBeInstanceOf(Axis);
   });
 });

--- a/src/types/axis.ts
+++ b/src/types/axis.ts
@@ -1,53 +1,53 @@
 import { Color, newColor } from "./color";
 import { Font, FontStyle, newFont } from "./font";
 
-export class Axis {
-  public xAxis: boolean;
-  public color: Color;
-  public title: string;
-  public showGrid: boolean;
-  public visible: boolean;
-  public logScale: boolean;
-  public autoscale: boolean;
-  public maximum: number;
-  public minimum: number;
-  public titleFont: Font;
-  public scaleFont: Font;
-  public onRight: boolean;
-
-  /**
-   * Set default values for properties not yet
-   * set, otherwise use set property. Uses same
-   * default values as csstudio.opibuilder.xygraph.
-   */
-  public constructor({
-    xAxis = false,
-    color = newColor("rgb(0, 0, 0)"),
-    title = "",
-    showGrid = false,
-    visible = true,
-    logScale = false,
-    autoscale = false,
-    minimum = 0,
-    maximum = 100,
-    titleFont = newFont(14, FontStyle.Bold),
-    scaleFont = newFont(12, FontStyle.Regular),
-    onRight = false,
-    fromOpi = false
-  } = {}) {
-    this.xAxis = xAxis;
-    this.color = color;
-    this.title = title || (xAxis ? "X" : "Y");
-    this.showGrid = showGrid;
-    this.visible = visible;
-    this.logScale = logScale;
-    this.autoscale = autoscale;
-    this.minimum = minimum;
-    this.maximum = maximum;
-    this.titleFont = titleFont;
-    this.scaleFont = scaleFont;
-    this.onRight = fromOpi ? !onRight : onRight;
-  }
+export interface Axis {
+  xAxis: boolean;
+  color: Color;
+  title: string;
+  showGrid: boolean;
+  visible: boolean;
+  logScale: boolean;
+  autoscale: boolean;
+  maximum: number;
+  minimum: number;
+  titleFont: Font;
+  scaleFont: Font;
+  onRight: boolean;
 }
+
+/**
+ * Set default values for properties not yet
+ * set, otherwise use set property. Uses same
+ * default values as csstudio.opibuilder.xygraph.
+ */
+export const newAxis = (config: {
+  xAxis?: boolean;
+  color?: Color;
+  title?: string;
+  showGrid?: boolean;
+  visible?: boolean;
+  logScale?: boolean;
+  autoscale?: boolean;
+  maximum?: number;
+  minimum?: number;
+  titleFont?: Font;
+  scaleFont?: Font;
+  onRight?: boolean;
+  fromOpi?: boolean;
+}): Axis => ({
+  xAxis: config.xAxis ?? false,
+  color: config.color ?? newColor("rgb(0, 0, 0)"),
+  title: config.title ?? (config.xAxis ? "X" : "Y"),
+  showGrid: config.showGrid ?? false,
+  visible: config.visible ?? true,
+  logScale: config.logScale ?? false,
+  autoscale: config.autoscale ?? false,
+  minimum: config.minimum ?? 0,
+  maximum: config.maximum ?? 100,
+  titleFont: config.titleFont ?? newFont(14, FontStyle.Bold),
+  scaleFont: config.scaleFont ?? newFont(12, FontStyle.Regular),
+  onRight: config.fromOpi ? !config.onRight : (config.onRight ?? false)
+});
 
 export type Axes = Axis[];

--- a/src/types/color.test.ts
+++ b/src/types/color.test.ts
@@ -1,4 +1,5 @@
-import { colorChangeAlpha, newColor } from "./color";
+import { colorChangeAlpha, newColor, newColorBar } from "./color";
+import { newFont } from "./font";
 
 describe("Color", (): void => {
   it.each<[string]>([["green"], ["red"]])(
@@ -31,6 +32,36 @@ describe("Color", (): void => {
       const initialColor = newColor("hsl(210, 50%, 50%)");
       const fadedColor = colorChangeAlpha(initialColor, 0.3);
       expect(fadedColor.colorString).toBe("rgba(64, 128, 191, 0.3)");
+    });
+  });
+});
+
+describe("newColorBar", (): void => {
+  it("sets default values on creation", () => {
+    const colorBar = newColorBar();
+    expect(colorBar).toEqual({
+      barSize: 40,
+      scaleFont: {
+        name: undefined,
+        size: 12,
+        style: "Regular",
+        typeface: "Liberation sans"
+      },
+      visible: false
+    });
+  });
+
+  it("correctly sets properties", () => {
+    const colorBar = newColorBar(false, 20, newFont(16));
+    expect(colorBar).toEqual({
+      barSize: 20,
+      scaleFont: {
+        name: undefined,
+        size: 16,
+        style: "Regular",
+        typeface: "Liberation sans"
+      },
+      visible: false
     });
   });
 });

--- a/src/types/color.test.ts
+++ b/src/types/color.test.ts
@@ -38,7 +38,7 @@ describe("Color", (): void => {
 
 describe("newColorBar", (): void => {
   it("sets default values on creation", () => {
-    const colorBar = newColorBar();
+    const colorBar = newColorBar({});
     expect(colorBar).toEqual({
       barSize: 40,
       scaleFont: {
@@ -52,7 +52,11 @@ describe("newColorBar", (): void => {
   });
 
   it("correctly sets properties", () => {
-    const colorBar = newColorBar(false, 20, newFont(16));
+    const colorBar = newColorBar({
+      visible: false,
+      barSize: 20,
+      scaleFont: newFont(16)
+    });
     expect(colorBar).toEqual({
       barSize: 20,
       scaleFont: {

--- a/src/types/color.ts
+++ b/src/types/color.ts
@@ -60,14 +60,14 @@ export interface ColorBar {
   scaleFont: Font;
 }
 
-export const newColorBar = (
-  visible?: boolean,
-  barSize?: number,
-  scaleFont?: Font
-): ColorBar => ({
-  visible: visible ?? false,
-  barSize: barSize ?? 40,
-  scaleFont: scaleFont ?? newFont(12, FontStyle.Regular)
+export const newColorBar = (config: {
+  visible?: boolean;
+  barSize?: number;
+  scaleFont?: Font;
+}): ColorBar => ({
+  visible: config.visible ?? false,
+  barSize: config.barSize ?? 40,
+  scaleFont: config.scaleFont ?? newFont(12, FontStyle.Regular)
 });
 
 export const colorChangeAlpha = (color: Color, a: number): Color => {

--- a/src/types/color.ts
+++ b/src/types/color.ts
@@ -1,7 +1,20 @@
 import { colord } from "colord";
+import { Font, newFont, FontStyle } from "./font";
 
 export interface Color {
   colorString: string;
+}
+
+// Map to names of Color Maps in h5web/lib
+export enum ColorMap {
+  VIRIDIS = "Viridis",
+  GRAY = "Greys",
+  JET = "Spectral",
+  SPECTRUM = "HSL",
+  HOT = "Warm",
+  COOL = "Cool",
+  SHADED = "Reds",
+  MAGMA = "Magma"
 }
 
 export const newColor = (colorString: string): Color => ({
@@ -40,6 +53,22 @@ export class ColorUtils {
     return newColor(`rgba(${r},${g},${b},${a})`);
   }
 }
+
+export interface ColorBar {
+  visible: boolean;
+  barSize: number;
+  scaleFont: Font;
+}
+
+export const newColorBar = (
+  visible?: boolean,
+  barSize?: number,
+  scaleFont?: Font
+): ColorBar => ({
+  visible: visible ?? false,
+  barSize: barSize ?? 40,
+  scaleFont: scaleFont ?? newFont(12, FontStyle.Regular)
+});
 
 export const colorChangeAlpha = (color: Color, a: number): Color => {
   return newColor(colord(color.colorString).alpha(a).toRgbString());

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export { type Position, newRelativePosition } from "./position";
-export { type Color, ColorUtils } from "./color";
+export { type Color, ColorUtils, type ColorBar } from "./color";
 export type { PV } from "./pv";
 export type { Font } from "./font";
 export { FontStyle } from "./font";

--- a/src/types/plt.test.ts
+++ b/src/types/plt.test.ts
@@ -1,4 +1,4 @@
-import { Axis } from "./axis";
+import { newAxis } from "./axis";
 import { ColorUtils } from "./color";
 import { newFont } from "./font";
 import { Plt } from "./plt";
@@ -8,7 +8,7 @@ describe("Plt", () => {
   it("constructs the plt with values", (): void => {
     const testValues = {
       title: "Testing",
-      axes: [new Axis(), new Axis({ color: ColorUtils.RED })],
+      axes: [newAxis({}), newAxis({ color: ColorUtils.RED })],
       pvlist: [new Trace({ yPv: "TEST" })],
       background: ColorUtils.WHITE,
       foreground: ColorUtils.RED,
@@ -27,7 +27,7 @@ describe("Plt", () => {
     const plt = new Plt(testValues);
     const actualValues = {
       title: "Testing",
-      axes: [new Axis(), new Axis({ color: ColorUtils.RED })],
+      axes: [newAxis({}), newAxis({ color: ColorUtils.RED })],
       pvlist: [new Trace({ yPv: "TEST" })],
       backgroundColor: ColorUtils.WHITE.colorString,
       foregroundColor: ColorUtils.RED.colorString,

--- a/src/types/plt.ts
+++ b/src/types/plt.ts
@@ -1,4 +1,4 @@
-import { Axes, Axis } from "./axis";
+import { Axes, newAxis } from "./axis";
 import { Color, ColorUtils } from "./color";
 import { Font, newFont } from "./font";
 import { Trace } from "./trace";
@@ -27,7 +27,7 @@ export class Plt {
    */
   public constructor({
     title = "",
-    axes = [new Axis()],
+    axes = [newAxis({})],
     pvlist = [new Trace()],
     background = ColorUtils.WHITE,
     foreground = ColorUtils.BLACK,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,4 +1,4 @@
-import { Color } from "./color";
+import { Color, ColorBar } from "./color";
 import { Font } from "./font";
 import { MacroMap } from "./macros";
 import { WidgetActions } from "../ui/widgets/widgetActions";
@@ -42,7 +42,8 @@ export type GenericProp =
   | ResponsiveBreakpoints
   | ResponsiveColumns
   | ResponsiveGridLayout
-  | ResponsiveLayout;
+  | ResponsiveLayout
+  | ColorBar;
 
 export interface Expression {
   boolExp: string;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -15,6 +15,7 @@ import {
   ResponsiveGridLayout,
   ResponsiveLayout
 } from "./responsiveBreakpoints";
+import { Rois } from "./rois";
 
 export type GenericProp =
   | string
@@ -43,7 +44,8 @@ export type GenericProp =
   | ResponsiveColumns
   | ResponsiveGridLayout
   | ResponsiveLayout
-  | ColorBar;
+  | ColorBar
+  | Rois;
 
 export interface Expression {
   boolExp: string;

--- a/src/types/rois.test.ts
+++ b/src/types/rois.test.ts
@@ -1,0 +1,31 @@
+import { ColorUtils, newColor } from "./color";
+import { newRoi } from "./rois";
+
+describe("Roi", () => {
+  it("constructs the region of interest with values", (): void => {
+    const testValues = {
+      name: "Testing",
+      color: newColor("rgb(24, 76, 155"),
+      visible: false,
+      interactive: false,
+      xPv: "TEST-X:01",
+      yPv: "TEST-Y:02",
+      heightPv: "TEST-W:03",
+      widthPv: "TEST-H:04"
+    };
+    const roi = newRoi(testValues);
+
+    expect(roi).toEqual(testValues);
+  });
+
+  it("constructs the region of interest with only defaults", (): void => {
+    const roi = newRoi({});
+
+    expect(roi).toEqual({
+      name: "",
+      color: ColorUtils.RED,
+      visible: true,
+      interactive: true
+    });
+  });
+});

--- a/src/types/rois.ts
+++ b/src/types/rois.ts
@@ -1,0 +1,37 @@
+import { Color, ColorUtils } from ".";
+
+export interface Roi {
+  name: string;
+  color: Color;
+  visible: boolean;
+  interactive: boolean;
+  xPv?: string;
+  yPv?: string;
+  heightPv?: string;
+  widthPv?: string;
+  file?: string;
+}
+
+export const newRoi = (config: {
+  name?: string;
+  color?: Color;
+  visible?: boolean;
+  interactive?: boolean;
+  xPv?: string;
+  yPv?: string;
+  heightPv?: string;
+  widthPv?: string;
+  file?: string;
+}): Roi => ({
+  name: config.name ?? "",
+  color: config.color ?? ColorUtils.RED,
+  visible: config.visible ?? true,
+  interactive: config.interactive ?? true,
+  xPv: config.xPv,
+  yPv: config.yPv,
+  widthPv: config.widthPv,
+  heightPv: config.heightPv,
+  file: config.file
+});
+
+export type Rois = Roi[];

--- a/src/ui/hooks/useArchivedData.test.tsx
+++ b/src/ui/hooks/useArchivedData.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useArchivedData } from "./useArchivedData";
 import { Plt } from "../../types/plt";
 import { vi } from "vitest";
-import { Axis } from "../../types/axis";
+import { newAxis } from "../../types/axis";
 import { Trace } from "../../types/trace";
 import { act, screen } from "@testing-library/react";
 import { contextRender } from "../../testResources";
@@ -68,7 +68,7 @@ describe("useArchivedData", (): void => {
           yPv: "TEST:PV"
         })
       ],
-      axes: [new Axis()]
+      axes: [newAxis({})]
     });
     await act(async () => {
       return contextRender(<ArchivedDataTester plt={plt} />);

--- a/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
+++ b/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from "@testing-library/react";
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { DataBrowserComponent } from "./dataBrowser";
 import { Trace } from "../../../types/trace";
-import { Axis } from "../../../types/axis";
+import { newAxis } from "../../../types/axis";
 import { Plt } from "../../../types/plt";
 import { PvDatum } from "../../../redux/csState";
 import { newDTime, newDType } from "../../../types/dtypes";
@@ -86,7 +86,7 @@ describe("DataBrowserComponent", () => {
           yPv: "TEST:PV"
         })
       ],
-      axes: [new Axis()]
+      axes: [newAxis({})]
     })
   };
 
@@ -136,8 +136,8 @@ describe("DataBrowserComponent", () => {
 
     test("renders with 1 y axis on either side", async () => {
       const axes = [
-        new Axis({ color: ColorUtils.RED }),
-        new Axis({ color: ColorUtils.BLUE, onRight: true })
+        newAxis({ color: ColorUtils.RED }),
+        newAxis({ color: ColorUtils.BLUE, onRight: true })
       ];
       const newProps = {
         ...defaultProps,
@@ -170,7 +170,7 @@ describe("DataBrowserComponent", () => {
               yPv: "TEST:PV"
             })
           ],
-          axes: [new Axis()]
+          axes: [newAxis({})]
         })
       };
 

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -5,30 +5,66 @@ import {
   InferWidgetProps,
   MacrosPropOpt,
   ColorPropOpt,
-  StringArrayPropOpt
+  StringArrayPropOpt,
+  AxisPropOpt,
+  FloatPropOpt,
+  IntPropOpt,
+  BoolPropOpt,
+  ColorBarPropOpt,
+  ColorMapPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
 import { getPvValueAndName } from "../utils";
 import { useNotification } from "../../hooks";
+import { Axis } from "../../../types/axis";
+import { ColorMap, newColorBar } from "../../../types/color";
 
 const widgetName = "demoImage";
 
 const DemoImageProps = {
   macros: MacrosPropOpt,
   backgroundColor: ColorPropOpt,
-  mjpgEndpoints: StringArrayPropOpt
+  mjpgEndpoints: StringArrayPropOpt,
+  colorBar: ColorBarPropOpt,
+  colorMap: ColorMapPropOpt,
+  xAxis: AxisPropOpt,
+  yAxis: AxisPropOpt,
+  minimum: FloatPropOpt,
+  maximum: FloatPropOpt,
+  dataWidth: IntPropOpt,
+  dataHeight: IntPropOpt,
+  logScale: BoolPropOpt,
+  autoScale: BoolPropOpt,
+  cursorCrosshair: BoolPropOpt,
+  limitsFromPv: BoolPropOpt,
+  unsignedData: BoolPropOpt,
+  visible: BoolPropOpt
 };
 
 export const DemoImageComponent = (
   props: InferWidgetProps<typeof DemoImageProps> & PVComponent
 ): JSX.Element => {
+  const {
+    colorMap = ColorMap.VIRIDIS,
+    colorBar = newColorBar(),
+    xAxis = new Axis({ xAxis: true }),
+    yAxis = new Axis(),
+    limitsFromPv = false,
+    logScale = false,
+    minimum = 0, // These are color bar limits
+    maximum = 255,
+    dataWidth = 100,
+    dataHeight = 100,
+    visible = true
+  } = props;
   const { colors } = useStyle(props, widgetName);
   const { effectivePvName } = getPvValueAndName(props?.pvData);
   const urls = buildMjpgPvUrls(props?.mjpgEndpoints, effectivePvName);
 
   const [src, setSrc] = useState(urls?.[0]);
+
   const [numberOfFailures, setNumberOfFailures] = useState(0);
   const { showWarning } = useNotification();
 

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -11,15 +11,16 @@ import {
   IntPropOpt,
   BoolPropOpt,
   ColorBarPropOpt,
-  ColorMapPropOpt
+  RoisPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
 import { getPvValueAndName } from "../utils";
 import { useNotification } from "../../hooks";
-import { Axis, newAxis } from "../../../types/axis";
-import { ColorMap, newColorBar } from "../../../types/color";
+// import { newAxis } from "../../../types/axis";
+// import { ColorMap, newColorBar } from "../../../types/color";
 
 const widgetName = "demoImage";
 
@@ -28,7 +29,7 @@ const DemoImageProps = {
   backgroundColor: ColorPropOpt,
   mjpgEndpoints: StringArrayPropOpt,
   colorBar: ColorBarPropOpt,
-  colorMap: ColorMapPropOpt,
+  colorMap: StringPropOpt,
   xAxis: AxisPropOpt,
   yAxis: AxisPropOpt,
   minimum: FloatPropOpt,
@@ -40,28 +41,29 @@ const DemoImageProps = {
   cursorCrosshair: BoolPropOpt,
   limitsFromPv: BoolPropOpt,
   unsignedData: BoolPropOpt,
-  visible: BoolPropOpt
+  visible: BoolPropOpt,
+  regionsOfInterest: RoisPropOpt
 };
 
 export const DemoImageComponent = (
   props: InferWidgetProps<typeof DemoImageProps> & PVComponent
 ): JSX.Element => {
-  const {
-    colorMap = ColorMap.VIRIDIS,
-    colorBar = newColorBar({}),
-    xAxis = newAxis({ xAxis: true }),
-    yAxis = newAxis({}),
-    limitsFromPv = false,
-    logScale = false,
-    minimum = 0, // These are color bar limits
-    maximum = 255,
-    dataWidth = 100,
-    dataHeight = 100,
-    visible = true
-  } = props;
+  // const {
+  //   colorMap = ColorMap.VIRIDIS,
+  //   colorBar = newColorBar({}),
+  //   xAxis = newAxis({ xAxis: true }),
+  //   yAxis = newAxis({}),
+  //   limitsFromPv = false,
+  //   logScale = false,
+  //   minimum = 0, // These are color bar limits
+  //   maximum = 255,
+  //   dataWidth = 100,
+  //   dataHeight = 100,
+  //   visible = true
+  // } = props;
   const { colors } = useStyle(props, widgetName);
   const { effectivePvName } = getPvValueAndName(props?.pvData);
-  const urls = buildMjpgPvUrls(["http://localhost:8090/mjpg"], effectivePvName);
+  const urls = buildMjpgPvUrls(props.mjpgEndpoints, effectivePvName);
 
   const [src, setSrc] = useState(urls?.[0]);
 

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -18,7 +18,7 @@ import { Box } from "@mui/material";
 import { useStyle } from "../../hooks/useStyle";
 import { getPvValueAndName } from "../utils";
 import { useNotification } from "../../hooks";
-import { Axis } from "../../../types/axis";
+import { Axis, newAxis } from "../../../types/axis";
 import { ColorMap, newColorBar } from "../../../types/color";
 
 const widgetName = "demoImage";
@@ -48,9 +48,9 @@ export const DemoImageComponent = (
 ): JSX.Element => {
   const {
     colorMap = ColorMap.VIRIDIS,
-    colorBar = newColorBar(),
-    xAxis = new Axis({ xAxis: true }),
-    yAxis = new Axis(),
+    colorBar = newColorBar({}),
+    xAxis = newAxis({ xAxis: true }),
+    yAxis = newAxis({}),
     limitsFromPv = false,
     logScale = false,
     minimum = 0, // These are color bar limits
@@ -61,7 +61,7 @@ export const DemoImageComponent = (
   } = props;
   const { colors } = useStyle(props, widgetName);
   const { effectivePvName } = getPvValueAndName(props?.pvData);
-  const urls = buildMjpgPvUrls(props?.mjpgEndpoints, effectivePvName);
+  const urls = buildMjpgPvUrls(["http://localhost:8090/mjpg"], effectivePvName);
 
   const [src, setSrc] = useState(urls?.[0]);
 
@@ -91,7 +91,7 @@ export const DemoImageComponent = (
         width: "100%",
         height: "100%",
         display: "block",
-        objectFit: "contain",
+        objectFit: "cover",
         backgroundColor: colors?.backgroundColor
       }}
     />

--- a/src/ui/widgets/DynamicImage/demoImage.tsx
+++ b/src/ui/widgets/DynamicImage/demoImage.tsx
@@ -63,10 +63,9 @@ export const DemoImageComponent = (
   // } = props;
   const { colors } = useStyle(props, widgetName);
   const { effectivePvName } = getPvValueAndName(props?.pvData);
-  const urls = buildMjpgPvUrls(props.mjpgEndpoints, effectivePvName);
+  const urls = buildMjpgPvUrls(props?.mjpgEndpoints, effectivePvName);
 
   const [src, setSrc] = useState(urls?.[0]);
-
   const [numberOfFailures, setNumberOfFailures] = useState(0);
   const { showWarning } = useNotification();
 
@@ -93,7 +92,7 @@ export const DemoImageComponent = (
         width: "100%",
         height: "100%",
         display: "block",
-        objectFit: "cover",
+        objectFit: "contain",
         backgroundColor: colors?.backgroundColor
       }}
     />

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
@@ -1,7 +1,9 @@
-import { ColorUtils } from "../../../types/color";
+import { ColorUtils, newColor } from "../../../types/color";
 import { newAbsolutePosition } from "../../../types/position";
 import {
   BOB_SIMPLE_PARSERS,
+  bobParseColorBar,
+  bobParseRois,
   normalizeCssPosition,
   parseBob
 } from "./bobParser";
@@ -9,6 +11,7 @@ import { PVUtils } from "../../../types/pv";
 import { ensureWidgetsRegistered } from "..";
 import { WidgetDescription } from "../createComponent";
 import { ElementCompact } from "xml-js";
+import { FontStyle, newFont } from "../../../types/font";
 ensureWidgetsRegistered();
 
 const PREFIX = "prefix";
@@ -344,6 +347,96 @@ describe("bobParseSymbols", () => {
 
     expect(() => bobParseSymbols(input)).not.toThrow();
     expect(bobParseSymbols(input)).toEqual(["IBM", "ORCL"]);
+  });
+});
+
+describe("bobParseRois", () => {
+  it("parses an array of regions", () => {
+    const rois = [
+      {
+        name: { _text: "TEST" },
+        xPv: { _text: "FIRST" },
+        yPv: { _text: "SECOND" },
+        heightPv: { _text: "THIRD" },
+        widthPv: { _text: "FOURTH" }
+      },
+      {
+        name: { _text: "TEST2" },
+        xPv: { _text: "FIRST" },
+        yPv: { _text: "SECOND" },
+        widthPv: { _text: "FOURTH" }
+      }
+    ];
+    const input: ElementCompact = { roi: rois };
+
+    const result = bobParseRois(input);
+    expect(result).toEqual([
+      {
+        color: newColor("rgba(255,0,0,1)"),
+        file: undefined,
+        heightPv: "THIRD",
+        interactive: true,
+        name: "TEST",
+        visible: true,
+        widthPv: "FOURTH",
+        xPv: "FIRST",
+        yPv: "SECOND"
+      },
+      {
+        color: newColor("rgba(255,0,0,1)"),
+        file: undefined,
+        interactive: true,
+        name: "TEST2",
+        visible: true,
+        widthPv: "FOURTH",
+        xPv: "FIRST",
+        yPv: "SECOND"
+      }
+    ]);
+  });
+
+  it("parses a single region", () => {
+    const input: ElementCompact = {
+      roi: {
+        name: { _text: "TEST" },
+        xPv: { _text: "FIRST" },
+        yPv: { _text: "SECOND" },
+        heightPv: { _text: "THIRD" },
+        widthPv: { _text: "FOURTH" }
+      }
+    };
+
+    const result = bobParseRois(input);
+    expect(result).toEqual([
+      {
+        color: newColor("rgba(255,0,0,1)"),
+        file: undefined,
+        heightPv: "THIRD",
+        interactive: true,
+        name: "TEST",
+        visible: true,
+        widthPv: "FOURTH",
+        xPv: "FIRST",
+        yPv: "SECOND"
+      }
+    ]);
+  });
+});
+
+describe("bobParseColorBar", () => {
+  it("parses colorBar props", () => {
+    const input = {
+      color_bar: {
+        bar_size: { _text: 20 },
+        visible: { _text: "false" }
+      }
+    };
+    const result = bobParseColorBar(input);
+    expect(result).toEqual({
+      barSize: 20,
+      scaleFont: newFont(12, FontStyle.Regular),
+      visible: false
+    });
   });
 });
 

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -596,6 +596,8 @@ export const BOB_SIMPLE_PARSERS: ParserDict = {
   displayHorizontal: ["displayHorizontal", opiParseBoolean],
   xPv: ["xPv", opiParseString],
   yPv: ["yPv", opiParseString],
+  heightPv: ["heightPv", opiParseString],
+  widthPv: ["widthPv", opiParseString],
   axis: ["axis", bobParseNumber],
   pointType: ["point_type", bobParseNumber],
   pointStyle: ["point_style", bobParseNumber],

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -41,7 +41,7 @@ import {
   BorderStyle,
   newBorder
 } from "../../../types/border";
-import { ColorUtils } from "../../../types/color";
+import { ColorBar, ColorUtils, newColorBar } from "../../../types/color";
 import { WidgetDescription } from "../createComponent";
 import { newPoint, newPoints, Point, Points } from "../../../types/points";
 import { Axis } from "../../../types/axis";
@@ -111,6 +111,7 @@ export const WIDGET_DEFAULT_SIZES: { [key: string]: [number, number] } = {
   ellipse: [100, 50],
   embedded: [400, 300],
   group: [300, 200],
+  image: [400, 300],
   label: [100, 20],
   led: [20, 20],
   linearmeter: [120, 120],
@@ -362,6 +363,27 @@ function bobParseXAxis(props: any): Axis {
 }
 
 /**
+ * Parses a color map, used in Heatmap and Image widgets
+ * @param props
+ * @returns
+ */
+function bobParseColorMap(props: any): string {
+  // Can also specify custom color maps with sections
+  // but for now we'll use named ones
+  const name = opiParseString(props.color_map.name);
+  return name;
+}
+
+/**
+ * Parses props for the color bar attached to a color map
+ * @param props
+ */
+function bobParseColorBar(props: any): ColorBar {
+  const parsedProps = parseChildProps(props.color_bar, BOB_SIMPLE_PARSERS) as ColorBar;
+  return parsedProps;
+}
+
+/**
  * Parses the tabs object, and any child widgets it may have
  * @param props tab object
  * @param simpleParsers object, property parser for children
@@ -585,6 +607,10 @@ export const BOB_SIMPLE_PARSERS: ParserDict = {
   start: ["start", opiParseString],
   end: ["end", opiParseString],
   arrayIndex: ["array_index", bobParseNumber],
+  barSize: ["bar_size", bobParseNumber],
+  dataWidth: ["data_width", bobParseNumber],
+  dataHeight: ["data_height", bobParseNumber],
+  section: ["section", opiParseColor],
   direction: ["direction", bobParseNumber],
   gridCellDragEnabled: ["grid_cell_drag_enabled", opiParseBoolean],
   gridCellResizeEnabled: ["grid_cell_resize_enabled", opiParseBoolean],
@@ -611,7 +637,9 @@ const BOB_COMPLEX_PARSERS: ComplexParserDict = {
   border: bobParseBorder,
   alarmSensitive: bobParseAlarmSensitive,
   file: bobParseFile,
-  xAxis: bobParseXAxis
+  xAxis: bobParseXAxis,
+  colorBar: bobParseColorBar,
+  colorMap: bobParseColorMap
 };
 
 export async function parseBob(

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -371,7 +371,7 @@ function bobParseXAxis(props: any): Axis {
 function bobParseColorMap(props: any): string {
   // Can also specify custom color maps with sections
   // but for now we'll use named ones
-  const name = opiParseString(props.color_map.name);
+  const name = opiParseString(props?.color_map?.name);
   return name;
 }
 
@@ -379,8 +379,8 @@ function bobParseColorMap(props: any): string {
  * Parses props for the color bar attached to a color map
  * @param props
  */
-function bobParseColorBar(props: any): ColorBar {
-  const parsedProps = parseChildProps(props.color_bar, BOB_SIMPLE_PARSERS);
+export function bobParseColorBar(props: any): ColorBar {
+  const parsedProps = parseChildProps(props?.color_bar, BOB_SIMPLE_PARSERS);
   return newColorBar(parsedProps);
 }
 
@@ -388,21 +388,22 @@ function bobParseColorBar(props: any): ColorBar {
  * Parses an array of regions of interest
  * @param props regions of interest
  */
-function bobParseRois(props: any): Rois {
-  const rois: Rois = [];
+export function bobParseRois(jsonProp: ElementCompact): Rois {
+  let rois: Rois = [];
   let parsedProps = {};
-  if (props.rois.roi)
-    if (props.rois.roi.length > 1) {
-      // If only one region, we are passed an object instead
-      // of an array
-      props.rois.forEach((roi: any) => {
+  if (jsonProp.roi) {
+    if (jsonProp.roi.length > 1) {
+      rois = jsonProp.roi.map((roi: any) => {
         const parsedProps = parseChildProps(roi, BOB_SIMPLE_PARSERS);
-        rois.push(newRoi(parsedProps));
+        return newRoi(parsedProps);
       });
     } else {
-      parsedProps = parseChildProps(props.rois.roi, BOB_SIMPLE_PARSERS);
+      // If only one region, we are passed an object instead
+      // of an array
+      parsedProps = parseChildProps(jsonProp.roi, BOB_SIMPLE_PARSERS);
       rois.push(newRoi(parsedProps));
     }
+  }
   return rois;
 }
 
@@ -664,8 +665,7 @@ const BOB_COMPLEX_PARSERS: ComplexParserDict = {
   file: bobParseFile,
   xAxis: bobParseXAxis,
   colorBar: bobParseColorBar,
-  colorMap: bobParseColorMap,
-  regionsOfInterest: bobParseRois
+  colorMap: bobParseColorMap
 };
 
 export async function parseBob(
@@ -719,6 +719,7 @@ export async function parseBob(
       scriptParser(scripts, defaultProtocol, false),
     traces: (props: ElementCompact) => bobParseTraces(props["traces"]),
     axes: (props: ElementCompact) => bobParseYAxes(props["y_axes"]),
+    regionsOfInterest: (props: ElementCompact) => bobParseRois(props["rois"]),
     plt: async (props: ElementCompact) =>
       await parsePlt(props["file"], filepath, props._attributes?.type),
     colors: (props: ElementCompact) =>

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -390,11 +390,11 @@ export function bobParseColorBar(props: any): ColorBar {
  */
 export function bobParseRois(jsonProp: ElementCompact): Rois {
   let rois: Rois = [];
-  let parsedProps = {};
   if (jsonProp.roi) {
+    let parsedProps = {};
     if (jsonProp.roi.length > 1) {
       rois = jsonProp.roi.map((roi: any) => {
-        const parsedProps = parseChildProps(roi, BOB_SIMPLE_PARSERS);
+        parsedProps = parseChildProps(roi, BOB_SIMPLE_PARSERS);
         return newRoi(parsedProps);
       });
     } else {

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -44,7 +44,7 @@ import {
 import { ColorBar, ColorUtils, newColorBar } from "../../../types/color";
 import { WidgetDescription } from "../createComponent";
 import { newPoint, newPoints, Point, Points } from "../../../types/points";
-import { Axis } from "../../../types/axis";
+import { Axis, newAxis } from "../../../types/axis";
 import { Trace } from "../../../types/trace";
 import { parsePlt } from "./pltParser";
 import { scriptParser } from "./scripts/scriptParser";
@@ -341,12 +341,12 @@ function bobParseYAxes(props: any): Axis[] {
     // of an array
     if (props.y_axis.length > 1) {
       props.y_axis.forEach((axis: any) => {
-        parsedProps = parseChildProps(axis, BOB_SIMPLE_PARSERS);
-        axes.push(new Axis(parsedProps));
+        parsedProps = parseChildProps(axis, BOB_SIMPLE_PARSERS) as Axis;
+        axes.push(newAxis({ ...parsedProps }));
       });
     } else {
       parsedProps = parseChildProps(props.y_axis, BOB_SIMPLE_PARSERS);
-      axes.push(new Axis(parsedProps));
+      axes.push(newAxis(parsedProps));
     }
   }
   return axes;
@@ -359,7 +359,7 @@ function bobParseYAxes(props: any): Axis[] {
  */
 function bobParseXAxis(props: any): Axis {
   const parsedProps = parseChildProps(props.x_axis, BOB_SIMPLE_PARSERS);
-  return new Axis({ xAxis: true, ...parsedProps });
+  return newAxis({ xAxis: true, ...parsedProps });
 }
 
 /**
@@ -379,8 +379,8 @@ function bobParseColorMap(props: any): string {
  * @param props
  */
 function bobParseColorBar(props: any): ColorBar {
-  const parsedProps = parseChildProps(props.color_bar, BOB_SIMPLE_PARSERS) as ColorBar;
-  return parsedProps;
+  const parsedProps = parseChildProps(props.color_bar, BOB_SIMPLE_PARSERS);
+  return newColorBar(parsedProps);
 }
 
 /**

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -57,6 +57,7 @@ import {
   bobParseResponsiveLayout,
   bobParseResponsiveMargins
 } from "./BobParsers/responsiveLayoutBobParser";
+import { newRoi, Rois } from "../../../types/rois";
 
 const BOB_WIDGET_MAPPING: { [key: string]: any } = {
   action_button: "actionbutton",
@@ -384,6 +385,28 @@ function bobParseColorBar(props: any): ColorBar {
 }
 
 /**
+ * Parses an array of regions of interest
+ * @param props regions of interest
+ */
+function bobParseRois(props: any): Rois {
+  const rois: Rois = [];
+  let parsedProps = {};
+  if (props.rois.roi)
+    if (props.rois.roi.length > 1) {
+      // If only one region, we are passed an object instead
+      // of an array
+      props.rois.forEach((roi: any) => {
+        const parsedProps = parseChildProps(roi, BOB_SIMPLE_PARSERS);
+        rois.push(newRoi(parsedProps));
+      });
+    } else {
+      parsedProps = parseChildProps(props.rois.roi, BOB_SIMPLE_PARSERS);
+      rois.push(newRoi(parsedProps));
+    }
+  return rois;
+}
+
+/**
  * Parses the tabs object, and any child widgets it may have
  * @param props tab object
  * @param simpleParsers object, property parser for children
@@ -641,7 +664,8 @@ const BOB_COMPLEX_PARSERS: ComplexParserDict = {
   file: bobParseFile,
   xAxis: bobParseXAxis,
   colorBar: bobParseColorBar,
-  colorMap: bobParseColorMap
+  colorMap: bobParseColorMap,
+  regionsOfInterest: bobParseRois
 };
 
 export async function parseBob(

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -13,7 +13,7 @@ import {
   newRelativePosition
 } from "../../../types/position";
 import { Trace } from "../../../types/trace";
-import { Axis } from "../../../types/axis";
+import { Axis, newAxis } from "../../../types/axis";
 import {
   ComplexParserDict,
   ParserDict,
@@ -517,7 +517,7 @@ function opiParseAxes(props: any): Axis[] {
   const axes: Axis[] = [];
   // Parse all of the 'axis' properties
   for (let i = 0; i < count; i++) {
-    const axis = new Axis({
+    const axis = newAxis({
       fromOpi: true,
       ...parseMultipleNamedProps(`axis_${i}`, props)
     });

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -27,7 +27,12 @@ const PARSE_EMPTY_STRINGS = [
   "on_label",
   "off_label",
   "title",
-  "group_name"
+  "group_name",
+  "x_pv",
+  "y_pv",
+  "width_pv",
+  "height_pv",
+  "file"
 ];
 
 function isEmpty(obj: any): boolean {

--- a/src/ui/widgets/EmbeddedDisplay/pltParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/pltParser.ts
@@ -8,7 +8,7 @@ import {
   normalisePath
 } from "./opiParser";
 import { parseChildProps, ParserDict } from "./parser";
-import { Axis } from "../../../types/axis";
+import { Axis, newAxis } from "../../../types/axis";
 import { Archiver, Trace } from "../../../types/trace";
 import { Plt } from "../../../types/plt";
 import { httpRequest } from "../../../misc/httpClient";
@@ -153,7 +153,7 @@ function pltParseAxes(props: ElementCompact, pvAxes: any) {
     propAxes.forEach((axis: any, idx: number) => {
       parsedProps = parseChildProps(axis, PLT_PARSERS);
       axes.push(
-        new Axis({
+        newAxis({
           ...parsedProps,
           fromOpi: false,
           showGrid: parsedProps.grid,

--- a/src/ui/widgets/StripChart/stripChart.test.tsx
+++ b/src/ui/widgets/StripChart/stripChart.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { StripChartComponent } from "./stripChart";
 import { Trace } from "../../../types/trace";
-import { Axis } from "../../../types/axis";
+import { newAxis } from "../../../types/axis";
 import { convertStringTimePeriod } from "../utils";
 import { PvDatum } from "../../../redux/csState";
 import { newDTime, newDType } from "../../../types/dtypes";
@@ -63,7 +63,7 @@ describe("StripChartComponent", () => {
   const defaultProps = {
     pvData: [buildPvDatum("TEST:PV", 50)],
     traces: [new Trace()],
-    axes: [new Axis()]
+    axes: [newAxis({})]
   };
 
   beforeEach(() => {
@@ -103,8 +103,8 @@ describe("StripChartComponent", () => {
 
     test("renders with 2 y axes", () => {
       const axes = [
-        new Axis({ color: ColorUtils.RED }),
-        new Axis({ color: ColorUtils.BLUE })
+        newAxis({ color: ColorUtils.RED }),
+        newAxis({ color: ColorUtils.BLUE })
       ];
       render(<StripChartComponent {...defaultProps} axes={axes} />);
 
@@ -353,7 +353,7 @@ describe("StripChartComponent", () => {
     });
 
     test("applies log scale to y axis", () => {
-      const axes = [new Axis({ logScale: true })];
+      const axes = [newAxis({ logScale: true })];
       render(<StripChartComponent {...defaultProps} axes={axes} />);
 
       const lineChart = screen.getByTestId("line-chart");

--- a/src/ui/widgets/StripChart/stripChart.tsx
+++ b/src/ui/widgets/StripChart/stripChart.tsx
@@ -18,7 +18,7 @@ import { Box, Typography } from "@mui/material";
 import { CurveType, LineChart, XAxis, YAxis } from "@mui/x-charts";
 import { convertStringTimePeriod } from "../utils";
 import { Trace } from "../../../types/trace";
-import { Axis } from "../../../types/axis";
+import { Axes, newAxis } from "../../../types/axis";
 import {
   dTypeGetDoubleValue,
   dTypeGetTime,
@@ -95,7 +95,7 @@ export const StripChartComponent = (
 
   // If we're passed an empty array fill in defaults
   const localAxes = useMemo(
-    () => (axes.length > 0 ? [...axes] : [new Axis({ xAxis: false })]),
+    () => (axes.length > 0 ? [...(axes as Axes)] : [newAxis({ xAxis: false })]),
     [axes]
   );
   // Convert start time into milliseconds period

--- a/src/ui/widgets/XYPlot/xyPlot.tsx
+++ b/src/ui/widgets/XYPlot/xyPlot.tsx
@@ -22,7 +22,7 @@ import {
 } from "./xyPlotOptions";
 import { getPvValueAndName, trimFromString } from "../utils";
 import { Trace } from "../../../types/trace";
-import { Axis } from "../../../types/axis";
+import { Axes, Axis, newAxis } from "../../../types/axis";
 import { useStyle } from "../../hooks/useStyle";
 import { Box } from "@mui/material";
 
@@ -64,7 +64,7 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
     showPlotBorder,
     // showToolbar, // TO DO - do we want a toolbar as well?
     traces = [new Trace()],
-    axes = [new Axis({ xAxis: true }), new Axis({ xAxis: false })]
+    axes = [newAxis({ xAxis: true }), newAxis({ xAxis: false })]
   } = props;
   const { value } = getPvValueAndName(pvData);
 
@@ -83,9 +83,9 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
     if (typeof font?.fontSize === "string")
       font.fontSize = trimFromString(font.fontSize);
 
-    const newAxisOptions = createAxes(axes, font);
+    const newAxisOptions = createAxes(axes as Axes, font);
     newAxisOptions.forEach((newAxis: NewAxisSettings, index: number) => {
-      newAxis = calculateAxisLimits(axes[index], newAxis, dataSet);
+      newAxis = calculateAxisLimits(axes[index] as Axis, newAxis, dataSet);
     });
     // Set up plot appearance
     const plotLayout: any = {

--- a/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
@@ -1,4 +1,4 @@
-import { Axis } from "../../../types/axis";
+import { Axis, newAxis } from "../../../types/axis";
 import { newColor } from "../../../types/color";
 import { newDType } from "../../../types/dtypes";
 import { FontStyle, fontToCss, newFont } from "../../../types/font";
@@ -271,7 +271,7 @@ describe("Create trace options object", (): void => {
 describe("Create axis options object", (): void => {
   test("Create axis with title label", (): void => {
     const axes: Axis[] = [
-      new Axis({
+      newAxis({
         title: "Test Plot",
         visible: true,
         showGrid: true,
@@ -324,9 +324,9 @@ describe("Create axis options object", (): void => {
       xAxis: true
     };
     const axes: Axis[] = [
-      new Axis(axis),
-      new Axis({ ...axis, ...{ minimum: -5, xAxis: false } }),
-      new Axis({ ...axis, ...{ maximum: 50, xAxis: false } })
+      newAxis(axis),
+      newAxis({ ...axis, ...{ minimum: -5, xAxis: false } }),
+      newAxis({ ...axis, ...{ maximum: 50, xAxis: false } })
     ];
     const font = newFont(10, FontStyle.Regular, "sans");
     const axisOptions = createAxes(
@@ -376,9 +376,9 @@ describe("Create axis options object", (): void => {
     };
 
     const axes: Axis[] = [
-      new Axis(axis),
-      new Axis({ ...axis, ...{ minimum: -5, xAxis: false } }),
-      new Axis({ ...axis, ...{ maximum: 50, onRight: true } })
+      newAxis(axis),
+      newAxis({ ...axis, ...{ minimum: -5, xAxis: false } }),
+      newAxis({ ...axis, ...{ maximum: 50, onRight: true } })
     ];
     const font = newFont(10, FontStyle.Regular, "sans");
     const axisOptions = createAxes(

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -54,6 +54,12 @@ export const ColorPropOpt = PropTypes.shape({
 });
 export const ColorProp = ColorPropOpt.isRequired;
 
+export const ColorMapPropOpt = PropTypes.shape({
+  name: StringPropOpt,
+  section: PropTypes.arrayOf(ColorPropOpt)
+});
+export const ColorMapProp = ColorMapPropOpt.isRequired;
+
 const FontStyleProp = PropTypes.oneOf(Object.values(FontStyle)).isRequired;
 
 export const FontPropOpt = PropTypes.shape({
@@ -63,6 +69,13 @@ export const FontPropOpt = PropTypes.shape({
   name: StringPropOpt
 });
 export const FontProp = FontPropOpt.isRequired;
+
+export const ColorBarPropOpt = PropTypes.shape({
+  visible: BoolPropOpt,
+  barSize: IntPropOpt,
+  scaleFont: FontPropOpt
+});
+export const ColorBarProp = ColorBarPropOpt.isRequired;
 
 export const BorderStyleProp = PropTypes.oneOf(
   Object.values(BorderStyle)

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -3,7 +3,6 @@ import { FontStyle } from "../../types/font";
 import { BorderStyle } from "../../types/border";
 import { FileDescription } from "../../misc/fileContext";
 import { Trace } from "../../types/trace";
-import { Axis } from "../../types/axis";
 import { Plt } from "../../types/plt";
 import { PositionType } from "../../types/position";
 
@@ -89,8 +88,21 @@ export const BorderProp = BorderPropOpt.isRequired;
 export const TraceProp = PropTypes.instanceOf(Trace).isRequired;
 export const TracePropOpt = PropTypes.instanceOf(Trace);
 
-export const AxisProp = PropTypes.instanceOf(Axis).isRequired;
-export const AxisPropOpt = PropTypes.instanceOf(Axis);
+export const AxisPropOpt = PropTypes.shape({
+  xAxis: BoolPropOpt,
+  color: ColorPropOpt,
+  title: StringPropOpt,
+  showGrid: BoolPropOpt,
+  visible: BoolPropOpt,
+  logScale: BoolPropOpt,
+  autoscale: BoolPropOpt,
+  maximum: FloatPropOpt,
+  minimum: FloatPropOpt,
+  titleFont: FontPropOpt,
+  scaleFont: FontPropOpt,
+  onRight: BoolPropOpt
+});
+export const AxisProp = AxisPropOpt.isRequired;
 
 export const TracesProp = PropTypes.arrayOf(TraceProp).isRequired;
 export const TracesPropOpt = PropTypes.arrayOf(TracePropOpt);

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -53,9 +53,6 @@ export const ColorPropOpt = PropTypes.shape({
 });
 export const ColorProp = ColorPropOpt.isRequired;
 
-export const ColorMapPropOpt = PropTypes.string.isRequired;
-export const ColorMapProp = PropTypes.string;
-
 const FontStyleProp = PropTypes.oneOf(Object.values(FontStyle)).isRequired;
 
 export const FontPropOpt = PropTypes.shape({
@@ -184,6 +181,22 @@ export const RulePropType = PropTypes.shape({
   pvs: PropTypes.arrayOf(RulePvs).isRequired,
   expressions: PropTypes.arrayOf(RuleExpressions).isRequired
 });
+
+export const RoiPropOpt = PropTypes.shape({
+  name: StringProp,
+  visible: BoolProp,
+  interactive: BoolProp,
+  xPv: StringPropOpt,
+  yPv: StringPropOpt,
+  widthPv: StringPropOpt,
+  heightPv: StringPropOpt,
+  file: StringPropOpt
+});
+
+export const RoiProp = RoiPropOpt.isRequired;
+
+export const RoisProp = PropTypes.arrayOf(RoiProp).isRequired;
+export const RoisPropOpt = PropTypes.arrayOf(RoiPropOpt);
 
 export const ScriptPropType = PropTypes.shape({
   file: StringProp,

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -54,11 +54,8 @@ export const ColorPropOpt = PropTypes.shape({
 });
 export const ColorProp = ColorPropOpt.isRequired;
 
-export const ColorMapPropOpt = PropTypes.shape({
-  name: StringPropOpt,
-  section: PropTypes.arrayOf(ColorPropOpt)
-});
-export const ColorMapProp = ColorMapPropOpt.isRequired;
+export const ColorMapPropOpt = PropTypes.string.isRequired;
+export const ColorMapProp = PropTypes.string;
 
 const FontStyleProp = PropTypes.oneOf(Object.values(FontStyle)).isRequired;
 


### PR DESCRIPTION
- Adds parsing for Image widget props, such as color bar and regions of interest
- Color map tries to match names of colormaps to those available in h5web/lib, which Davidia uses 
- In the Image widget, I added prop defaults but left them commented out as they aren't used yet by the widget
- Reconfigured Axis prop to not use classes (this fixes a console error related to redux store serialisation)