### PR TITLE
Update Trace and Plt classes

### DIFF
--- a/src/types/plt.test.ts
+++ b/src/types/plt.test.ts
@@ -2,14 +2,14 @@ import { newAxis } from "./axis";
 import { ColorUtils } from "./color";
 import { newFont } from "./font";
 import { Plt } from "./plt";
-import { Trace } from "./trace";
+import { newTrace } from "./trace";
 
 describe("Plt", () => {
   it("constructs the plt with values", (): void => {
     const testValues = {
       title: "Testing",
       axes: [newAxis({}), newAxis({ color: ColorUtils.RED })],
-      pvlist: [new Trace({ yPv: "TEST" })],
+      pvlist: [newTrace({ yPv: "TEST" })],
       background: ColorUtils.WHITE,
       foreground: ColorUtils.RED,
       scroll: false,
@@ -28,7 +28,7 @@ describe("Plt", () => {
     const actualValues = {
       title: "Testing",
       axes: [newAxis({}), newAxis({ color: ColorUtils.RED })],
-      pvlist: [new Trace({ yPv: "TEST" })],
+      pvlist: [newTrace({ yPv: "TEST" })],
       backgroundColor: ColorUtils.WHITE.colorString,
       foregroundColor: ColorUtils.RED.colorString,
       scroll: false,

--- a/src/types/plt.test.ts
+++ b/src/types/plt.test.ts
@@ -1,7 +1,7 @@
 import { newAxis } from "./axis";
 import { ColorUtils } from "./color";
 import { newFont } from "./font";
-import { Plt } from "./plt";
+import { newPlt } from "./plt";
 import { newTrace } from "./trace";
 
 describe("Plt", () => {
@@ -24,7 +24,7 @@ describe("Plt", () => {
       start: "10 minutes",
       end: "now"
     };
-    const plt = new Plt(testValues);
+    const plt = newPlt(testValues);
     const actualValues = {
       title: "Testing",
       axes: [newAxis({}), newAxis({ color: ColorUtils.RED })],
@@ -54,11 +54,10 @@ describe("Plt", () => {
       axes: [],
       pvlist: []
     });
-    expect(plt).toBeInstanceOf(Plt);
   });
 
   it("construct the trace with only defaults", (): void => {
-    const plt = new Plt();
+    const plt = newPlt({});
     expect({
       ...plt,
       backgroundColor: plt.backgroundColor.colorString,
@@ -83,6 +82,5 @@ describe("Plt", () => {
       start: "1 minute",
       end: "now"
     });
-    expect(plt).toBeInstanceOf(Plt);
   });
 });

--- a/src/types/plt.ts
+++ b/src/types/plt.ts
@@ -1,7 +1,7 @@
 import { Axes, newAxis } from "./axis";
 import { Color, ColorUtils } from "./color";
 import { Font, newFont } from "./font";
-import { Trace } from "./trace";
+import { newTrace, Trace } from "./trace";
 
 export class Plt {
   public title: string;
@@ -28,7 +28,7 @@ export class Plt {
   public constructor({
     title = "",
     axes = [newAxis({})],
-    pvlist = [new Trace()],
+    pvlist = [newTrace({})],
     background = ColorUtils.WHITE,
     foreground = ColorUtils.BLACK,
     scroll = true,

--- a/src/types/plt.ts
+++ b/src/types/plt.ts
@@ -3,61 +3,57 @@ import { Color, ColorUtils } from "./color";
 import { Font, newFont } from "./font";
 import { newTrace, Trace } from "./trace";
 
-export class Plt {
-  public title: string;
-  public axes: Axes;
-  public pvlist: Trace[];
-  public backgroundColor: Color;
-  public foregroundColor: Color;
-  public scroll: boolean;
-  public scrollStep: number;
-  public updatePeriod: number;
-  public bufferSize: number;
-  public start: string;
-  public end: string;
-  public showGrid: boolean;
-  public titleFont: Font;
-  public scaleFont: Font;
-  public labelFont: Font;
-  public legendFont: Font;
-
-  /**
-   * Set default values for properties not yet
-   * set, otherwise use set property.
-   */
-  public constructor({
-    title = "",
-    axes = [newAxis({})],
-    pvlist = [newTrace({})],
-    background = ColorUtils.WHITE,
-    foreground = ColorUtils.BLACK,
-    scroll = true,
-    grid = false,
-    scrollStep = 5,
-    updatePeriod = 0,
-    bufferSize = 5000,
-    titleFont = newFont(),
-    labelFont = newFont(),
-    legendFont = newFont(),
-    scaleFont = newFont(),
-    start = "1 minute",
-    end = "now"
-  } = {}) {
-    this.backgroundColor = background;
-    this.foregroundColor = foreground;
-    this.title = title;
-    this.scroll = scroll;
-    this.scrollStep = scrollStep;
-    this.axes = axes;
-    this.pvlist = pvlist;
-    this.updatePeriod = updatePeriod;
-    this.bufferSize = bufferSize;
-    this.showGrid = grid;
-    this.start = start;
-    this.end = end;
-    this.titleFont = titleFont;
-    this.scaleFont = scaleFont;
-    this.labelFont = labelFont;
-    this.legendFont = legendFont;
-  }
+export interface Plt {
+  title: string;
+  axes: Axes;
+  pvlist: Trace[];
+  backgroundColor: Color;
+  foregroundColor: Color;
+  scroll: boolean;
+  scrollStep: number;
+  updatePeriod: number;
+  bufferSize: number;
+  start: string;
+  end: string;
+  showGrid: boolean;
+  titleFont: Font;
+  scaleFont: Font;
+  labelFont: Font;
+  legendFont: Font;
 }
+
+export const newPlt = (config: {
+  title?: string;
+  axes?: Axes;
+  pvlist?: Trace[];
+  background?: Color;
+  foreground?: Color;
+  scroll?: boolean;
+  scrollStep?: number;
+  updatePeriod?: number;
+  bufferSize?: number;
+  start?: string;
+  end?: string;
+  grid?: boolean;
+  titleFont?: Font;
+  scaleFont?: Font;
+  labelFont?: Font;
+  legendFont?: Font;
+}): Plt => ({
+  title: config.title ?? "",
+  axes: config.axes ?? [newAxis({})],
+  pvlist: config.pvlist ?? [newTrace({})],
+  backgroundColor: config.background ?? ColorUtils.WHITE,
+  foregroundColor: config.foreground ?? ColorUtils.BLACK,
+  scroll: config.scroll ?? true,
+  showGrid: config.grid ?? false,
+  scrollStep: config.scrollStep ?? 5,
+  updatePeriod: config.updatePeriod ?? 0,
+  bufferSize: config.bufferSize ?? 5000,
+  titleFont: config.titleFont ?? newFont(),
+  labelFont: config.labelFont ?? newFont(),
+  legendFont: config.legendFont ?? newFont(),
+  scaleFont: config.scaleFont ?? newFont(),
+  start: config.start ?? "1 minute",
+  end: config.end ?? "now"
+});

--- a/src/types/trace.test.ts
+++ b/src/types/trace.test.ts
@@ -1,5 +1,5 @@
 import { ColorUtils } from "./color";
-import { Trace } from "./trace";
+import { newTrace } from "./trace";
 
 describe("Trace", () => {
   it("constructs the trace with values", (): void => {
@@ -20,14 +20,13 @@ describe("Trace", () => {
         url: "Testing.diamond.ac.uk"
       }
     };
-    const trace = new Trace(testValues);
+    const trace = newTrace(testValues);
 
     expect(trace).toEqual(testValues);
-    expect(trace).toBeInstanceOf(Trace);
   });
 
   it("construct the trace with only defaults", (): void => {
-    const trace = new Trace();
+    const trace = newTrace({});
     expect({ ...trace, color: "" }).toEqual({
       name: "",
       axis: 0,
@@ -47,6 +46,5 @@ describe("Trace", () => {
     expect(trace.color.colorString).toEqual(
       ColorUtils.fromRgba(0, 0, 255).colorString
     );
-    expect(trace).toBeInstanceOf(Trace);
   });
 });

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -5,67 +5,72 @@ export interface Archiver {
   url: string;
 }
 
-export class Trace {
-  public name: string;
-  public axis: number;
-  public lineWidth: number;
-  public lineStyle: number;
-  public traceType: number;
-  public color: Color;
-  public pointType: number;
-  public pointSize: number;
-  public visible: boolean;
-  public yPv: string;
-  public xPv?: string | null;
-  public bufferSize?: number;
-  public plotMode?: number;
-  public antiAlias?: boolean;
-  public concatenateData?: boolean;
-  public updateDelay?: number;
-  public updateMode?: number;
-  public archive?: Archiver | undefined;
-
-  public constructor({
-    name = "",
-    axis = 0,
-    lineWidth = 0,
-    lineStyle = 0,
-    traceType = 2,
-    color = ColorUtils.fromRgba(0, 0, 255),
-    pointType = 0,
-    pointSize = 1,
-    visible = true,
-    xPv = "",
-    yPv = "",
-    fromOpi = false,
-    antiAlias = true,
-    bufferSize = 100,
-    concatenateData = true,
-    updateDelay = 100,
-    updateMode = 0,
-    plotMode = 0,
-    archive = { name: "", url: "" }
-  } = {}) {
-    // xPV property only exists on XYPlot
-    if (xPv) this.xPv = xPv;
-    this.yPv = yPv;
-    this.axis = axis;
-    this.name = name || (yPv ? yPv : "");
-    this.lineWidth = lineWidth;
-    this.lineStyle = lineStyle;
-    this.traceType = traceType;
-    this.color = color;
-    this.pointType = pointType;
-    this.pointSize = pointSize;
-    this.visible = visible;
-    if (archive) this.archive = archive;
-    if (fromOpi) {
-      this.antiAlias = antiAlias;
-      this.bufferSize = bufferSize;
-      this.concatenateData = concatenateData;
-      this.updateDelay = updateDelay;
-      this.updateMode = updateMode;
-      this.plotMode = plotMode;
-    }
-  }
+export interface Trace {
+  name: string;
+  axis: number;
+  lineWidth: number;
+  lineStyle: number;
+  traceType: number;
+  color: Color;
+  pointType: number;
+  pointSize: number;
+  visible: boolean;
+  yPv: string;
+  xPv?: string | null;
+  bufferSize?: number;
+  plotMode?: number;
+  antiAlias?: boolean;
+  concatenateData?: boolean;
+  updateDelay?: number;
+  updateMode?: number;
+  archive?: Archiver | undefined;
 }
+
+/**
+ * Set default values for properties not yet
+ * set, otherwise use set property. Uses same
+ * default values as csstudio.opibuilder.xygraph.
+ */
+export const newTrace = (config: {
+  name?: string;
+  axis?: number;
+  lineWidth?: number;
+  lineStyle?: number;
+  traceType?: number;
+  color?: Color;
+  pointType?: number;
+  pointSize?: number;
+  visible?: boolean;
+  yPv?: string;
+  xPv?: string | null;
+  bufferSize?: number;
+  plotMode?: number;
+  antiAlias?: boolean;
+  concatenateData?: boolean;
+  updateDelay?: number;
+  updateMode?: number;
+  archive?: Archiver | undefined;
+  fromOpi?: boolean;
+}): Trace => ({
+  name: config.name || (config.yPv ? config.yPv : ""),
+  axis: config.axis ?? 0,
+  lineWidth: config.lineWidth ?? 0,
+  lineStyle: config.lineStyle ?? 0,
+  traceType: config.traceType ?? 2,
+  archive: config.archive ?? { name: "", url: "" },
+  color: config.color ?? ColorUtils.fromRgba(0, 0, 255),
+  pointType: config.pointType ?? 0,
+  pointSize: config.pointSize ?? 1,
+  visible: config.visible ?? true,
+  ...(config.xPv && { xPv: config.xPv ?? "" }),
+  yPv: config.yPv ?? "",
+  // Legacy opi props
+  ...(config.fromOpi && {
+    antiAlias: config.antiAlias ?? true,
+    bufferSize: config.bufferSize ?? 100,
+    concatenateData: config.concatenateData ?? true,
+    updateDelay: config.updateDelay ?? 100,
+    updateMode: config.updateMode ?? 0,
+    plotMode: config.plotMode ?? 0
+  })
+});

--- a/src/ui/hooks/useArchivedData.test.tsx
+++ b/src/ui/hooks/useArchivedData.test.tsx
@@ -3,7 +3,7 @@ import { useArchivedData } from "./useArchivedData";
 import { Plt } from "../../types/plt";
 import { vi } from "vitest";
 import { newAxis } from "../../types/axis";
-import { Trace } from "../../types/trace";
+import { newTrace } from "../../types/trace";
 import { act, screen } from "@testing-library/react";
 import { contextRender } from "../../testResources";
 
@@ -60,7 +60,7 @@ describe("useArchivedData", (): void => {
   it("returns values if successful archiver call", async () => {
     const plt = new Plt({
       pvlist: [
-        new Trace({
+        newTrace({
           archive: {
             name: "Primary",
             url: "http://archiver.diamond.ac.uk/retrieval"

--- a/src/ui/hooks/useArchivedData.test.tsx
+++ b/src/ui/hooks/useArchivedData.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useArchivedData } from "./useArchivedData";
-import { Plt } from "../../types/plt";
+import { newPlt, Plt } from "../../types/plt";
 import { vi } from "vitest";
 import { newAxis } from "../../types/axis";
 import { newTrace } from "../../types/trace";
@@ -58,7 +58,7 @@ const ArchivedDataTester = (props: { plt: Plt }): JSX.Element => {
 
 describe("useArchivedData", (): void => {
   it("returns values if successful archiver call", async () => {
-    const plt = new Plt({
+    const plt = newPlt({
       pvlist: [
         newTrace({
           archive: {

--- a/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
+++ b/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
@@ -4,7 +4,7 @@ import { describe, test, expect, beforeEach, vi } from "vitest";
 import { DataBrowserComponent } from "./dataBrowser";
 import { newTrace } from "../../../types/trace";
 import { newAxis } from "../../../types/axis";
-import { Plt } from "../../../types/plt";
+import { newPlt } from "../../../types/plt";
 import { PvDatum } from "../../../redux/csState";
 import { newDTime, newDType } from "../../../types/dtypes";
 import { ColorUtils } from "../../../types/color";
@@ -76,7 +76,7 @@ describe("DataBrowserComponent", () => {
 
   const defaultProps = {
     pvData: [buildPvDatum("TEST:PV", 50)],
-    plt: new Plt({
+    plt: newPlt({
       pvlist: [
         newTrace({
           archive: {
@@ -141,7 +141,7 @@ describe("DataBrowserComponent", () => {
       ];
       const newProps = {
         ...defaultProps,
-        plt: new Plt({ axes: axes })
+        plt: newPlt({ axes: axes })
       };
       await act(async () => {
         contextRender(<DataBrowserComponent {...newProps} />);
@@ -158,7 +158,7 @@ describe("DataBrowserComponent", () => {
     test("renders with 5 minute archived data", async () => {
       const newProps = {
         ...defaultProps,
-        plt: new Plt({
+        plt: newPlt({
           start: "5 min",
           end: "now",
           pvlist: [

--- a/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
+++ b/src/ui/widgets/DataBrowser/dataBrowser.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { DataBrowserComponent } from "./dataBrowser";
-import { Trace } from "../../../types/trace";
+import { newTrace } from "../../../types/trace";
 import { newAxis } from "../../../types/axis";
 import { Plt } from "../../../types/plt";
 import { PvDatum } from "../../../redux/csState";
@@ -78,7 +78,7 @@ describe("DataBrowserComponent", () => {
     pvData: [buildPvDatum("TEST:PV", 50)],
     plt: new Plt({
       pvlist: [
-        new Trace({
+        newTrace({
           archive: {
             name: "Primary",
             url: "http://archiver.diamond.ac.uk/retrieval"
@@ -162,7 +162,7 @@ describe("DataBrowserComponent", () => {
           start: "5 min",
           end: "now",
           pvlist: [
-            new Trace({
+            newTrace({
               archive: {
                 name: "Primary",
                 url: "http://archiver.diamond.ac.uk/retrieval"

--- a/src/ui/widgets/DataBrowser/dataBrowser.tsx
+++ b/src/ui/widgets/DataBrowser/dataBrowser.tsx
@@ -10,6 +10,7 @@ import {
 import { registerWidget } from "../register";
 import { StripChartComponent } from "../StripChart/stripChart";
 import { useArchivedData } from "../../hooks/useArchivedData";
+import { Plt } from "../../../types/plt";
 
 const DataBrowserProps = {
   plt: PltProp,
@@ -28,7 +29,7 @@ export const DataBrowserComponent = (
   props: DataBrowserComponentProps
 ): JSX.Element => {
   const { plt } = props;
-  const [data, dataLoaded] = useArchivedData(plt);
+  const [data, dataLoaded] = useArchivedData(plt as Plt);
 
   return (
     <StripChartComponent

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -45,7 +45,7 @@ import { ColorBar, ColorUtils, newColorBar } from "../../../types/color";
 import { WidgetDescription } from "../createComponent";
 import { newPoint, newPoints, Point, Points } from "../../../types/points";
 import { Axis, newAxis } from "../../../types/axis";
-import { Trace } from "../../../types/trace";
+import { newTrace, Trace } from "../../../types/trace";
 import { parsePlt } from "./pltParser";
 import { scriptParser } from "./scripts/scriptParser";
 import { MacroMap } from "../../../types/macros";
@@ -321,11 +321,11 @@ function bobParseTraces(props: any): Trace[] {
     if (props.trace.length > 1) {
       props.trace.forEach((trace: any) => {
         parsedProps = parseChildProps(trace, BOB_SIMPLE_PARSERS);
-        traces.push(new Trace(parsedProps));
+        traces.push(newTrace(parsedProps));
       });
     } else {
       parsedProps = parseChildProps(props.trace, BOB_SIMPLE_PARSERS);
-      traces.push(new Trace(parsedProps));
+      traces.push(newTrace(parsedProps));
     }
   }
   return traces;

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -12,7 +12,7 @@ import {
   newAbsolutePosition,
   newRelativePosition
 } from "../../../types/position";
-import { Trace } from "../../../types/trace";
+import { newTrace, Trace } from "../../../types/trace";
 import { Axis, newAxis } from "../../../types/axis";
 import {
   ComplexParserDict,
@@ -502,7 +502,7 @@ function opiParseTraces(props: any): Trace[] {
   const traces: Trace[] = [];
   // Parse all of the 'trace' properties
   for (let i = 0; i < count; i++) {
-    const trace = new Trace({
+    const trace = newTrace({
       fromOpi: true,
       ...parseMultipleNamedProps(`trace_${i}`, props)
     });

--- a/src/ui/widgets/EmbeddedDisplay/pltParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/pltParser.ts
@@ -10,7 +10,7 @@ import {
 import { parseChildProps, ParserDict } from "./parser";
 import { Axis, newAxis } from "../../../types/axis";
 import { Archiver, newTrace, Trace } from "../../../types/trace";
-import { Plt } from "../../../types/plt";
+import { newPlt, Plt } from "../../../types/plt";
 import { httpRequest } from "../../../misc/httpClient";
 import { isFullyQualifiedUrl } from "../../../misc";
 import { ColorUtils } from "../../../types/color";
@@ -197,7 +197,7 @@ export async function parsePlt(
   widgetType?: string | number
 ): Promise<Plt> {
   // TO DO - check file ext is plt
-  let props = new Plt();
+  let props = newPlt({});
   if (widgetType === "databrowser" && typeof file._text === "string") {
     const databrowser: XmlDescription = await fetchPltFile(
       file._text,
@@ -206,7 +206,7 @@ export async function parsePlt(
     // Parse the simple props
     const [pvlist, pvAxes] = pltParsePvlist(databrowser["pvlist"]);
     const axes = pltParseAxes(databrowser["axes"], pvAxes);
-    props = new Plt({
+    props = newPlt({
       ...parseChildProps(databrowser, PLT_PARSERS),
       pvlist: pvlist,
       axes: axes

--- a/src/ui/widgets/EmbeddedDisplay/pltParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/pltParser.ts
@@ -9,7 +9,7 @@ import {
 } from "./opiParser";
 import { parseChildProps, ParserDict } from "./parser";
 import { Axis, newAxis } from "../../../types/axis";
-import { Archiver, Trace } from "../../../types/trace";
+import { Archiver, newTrace, Trace } from "../../../types/trace";
 import { Plt } from "../../../types/plt";
 import { httpRequest } from "../../../misc/httpClient";
 import { isFullyQualifiedUrl } from "../../../misc";
@@ -127,7 +127,7 @@ function pltParsePvlist(props: ElementCompact) {
         ? pvAxes[parsedProps.axis].push(parsedProps.name)
         : (pvAxes[parsedProps.axis] = [parsedProps.name]);
       traces.push(
-        new Trace({
+        newTrace({
           ...parsedProps,
           yPv: parsedProps.name,
           lineWidth: parsedProps.linewidth

--- a/src/ui/widgets/StripChart/stripChart.test.tsx
+++ b/src/ui/widgets/StripChart/stripChart.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { StripChartComponent } from "./stripChart";
-import { Trace } from "../../../types/trace";
+import { newTrace } from "../../../types/trace";
 import { newAxis } from "../../../types/axis";
 import { convertStringTimePeriod } from "../utils";
 import { PvDatum } from "../../../redux/csState";
@@ -62,7 +62,7 @@ describe("StripChartComponent", () => {
 
   const defaultProps = {
     pvData: [buildPvDatum("TEST:PV", 50)],
-    traces: [new Trace()],
+    traces: [newTrace({})],
     axes: [newAxis({})]
   };
 
@@ -132,8 +132,8 @@ describe("StripChartComponent", () => {
 
     test("renders with 2 traces", () => {
       const traces = [
-        new Trace({ color: ColorUtils.ORANGE, yPv: "TEST:PV" }),
-        new Trace({ color: ColorUtils.PINK, yPv: "TEST:PV" })
+        newTrace({ color: ColorUtils.ORANGE, yPv: "TEST:PV" }),
+        newTrace({ color: ColorUtils.PINK, yPv: "TEST:PV" })
       ];
       render(<StripChartComponent {...defaultProps} traces={traces} />);
       const lineChart = screen.getByTestId("line-chart");
@@ -153,9 +153,9 @@ describe("StripChartComponent", () => {
 
     test("renders multiple PVs with multiple traces, with rerender to add second set of PV data", () => {
       const traces = [
-        new Trace({ color: ColorUtils.ORANGE, yPv: "PV1" }),
-        new Trace({ color: ColorUtils.PINK, yPv: "PV2" }),
-        new Trace({ color: ColorUtils.BLUE, yPv: "PV3" })
+        newTrace({ color: ColorUtils.ORANGE, yPv: "PV1" }),
+        newTrace({ color: ColorUtils.PINK, yPv: "PV2" }),
+        newTrace({ color: ColorUtils.BLUE, yPv: "PV3" })
       ];
 
       const renderedObject = render(
@@ -302,7 +302,7 @@ describe("StripChartComponent", () => {
 
   describe("Styling", () => {
     test("applies tracetype to trace", () => {
-      const traces = [new Trace({ traceType: 5, yPv: "TEST:PV" })];
+      const traces = [newTrace({ traceType: 5, yPv: "TEST:PV" })];
 
       render(<StripChartComponent {...defaultProps} traces={traces} />);
 
@@ -340,7 +340,7 @@ describe("StripChartComponent", () => {
     });
 
     test("applies diamond markers to trace", () => {
-      const traces = [new Trace({ pointType: 3, yPv: "TEST:PV" })];
+      const traces = [newTrace({ pointType: 3, yPv: "TEST:PV" })];
       render(<StripChartComponent {...defaultProps} traces={traces} />);
 
       const lineChart = screen.getByTestId("line-chart");

--- a/src/ui/widgets/StripChart/stripChart.tsx
+++ b/src/ui/widgets/StripChart/stripChart.tsx
@@ -17,7 +17,7 @@ import { registerWidget } from "../register";
 import { Box, Typography } from "@mui/material";
 import { CurveType, LineChart, MarkShape, XAxis, YAxis } from "@mui/x-charts";
 import { convertStringTimePeriod } from "../utils";
-import { Trace } from "../../../types/trace";
+import { newTrace } from "../../../types/trace";
 import { Axes, newAxis } from "../../../types/axis";
 import {
   dTypeGetDoubleValue,
@@ -289,7 +289,7 @@ export const StripChartComponent = (
 
   const series = useMemo(
     () =>
-      (traces?.length > 0 ? traces : [new Trace()])
+      (traces?.length > 0 ? traces : [newTrace({})])
         ?.map((item, index) => {
           const pvName = item?.yPv;
           const effectivePvName = pvData
@@ -305,7 +305,7 @@ export const StripChartComponent = (
             id: `${index}`,
             dataKey: effectivePvName,
             label: item.name || pvName,
-            color: visible ? item.color.colorString : "transparent",
+            color: visible ? item.color?.colorString : "transparent",
             showMark: item.pointType === 0 ? false : true,
             area: item.traceType === 5 ? true : false,
             connectNulls: false,

--- a/src/ui/widgets/XYPlot/xyPlot.tsx
+++ b/src/ui/widgets/XYPlot/xyPlot.tsx
@@ -186,7 +186,7 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
                       // this hides the line if no line should be visible
                       if (
                         trace?.traceType != null &&
-                        traceTypesWithoutLines.includes(trace.traceType)
+                        traceTypesWithoutLines.includes(Number(trace.traceType)) //tracetype can only be string for databrowser
                       ) {
                         return {
                           stroke: "transparent"

--- a/src/ui/widgets/XYPlot/xyPlot.tsx
+++ b/src/ui/widgets/XYPlot/xyPlot.tsx
@@ -38,6 +38,7 @@ import {
   buildXAxes,
   buildYAxes
 } from "./xyPlot.utilities";
+import { Trace } from "../../../types/trace";
 
 const widgetName = "xyplot";
 
@@ -92,12 +93,12 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
 
   const { yAxes, yAxesStyle } = useMemo(() => buildYAxes(axes as Axes), [axes]);
   const { xAxis: xAxisMui, hasXAxisData } = useMemo(
-    () => buildXAxes(traces, style, xAxis as Axis),
+    () => buildXAxes(traces as Trace[], style, xAxis as Axis),
     [traces, style, xAxis]
   );
 
   const series = useMemo(
-    () => buildSeries(traces, pvData, visible),
+    () => buildSeries(traces as Trace[], pvData, visible),
     [traces, pvData, visible]
   );
 

--- a/src/ui/widgets/XYPlot/xyPlot.utilities.ts
+++ b/src/ui/widgets/XYPlot/xyPlot.utilities.ts
@@ -9,7 +9,7 @@ import {
 import { PvDatum } from "../../../redux/csState";
 import { dTypeCoerceArray } from "../../../types/dtypes";
 import { CurveType } from "@mui/x-charts";
-import { Trace } from "../../../types/trace";
+import { newTrace, Trace } from "../../../types/trace";
 import { UseStyleResult } from "../../hooks/useStyle";
 import { Axes, Axis, newAxis } from "../../../types/axis";
 import { fontToCss } from "../../../types/font";
@@ -55,7 +55,7 @@ export const buildSeries = (
   pvData: PvDatum[],
   visible: boolean
 ): (LineSeriesType | BarSeriesType)[] => {
-  return (traces ?? [new Trace()])
+  return (traces ?? [newTrace({})])
     .filter(trace => trace != null)
     .map((trace, index) => {
       const yPvName = trace?.yPv;

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -2,7 +2,6 @@ import PropTypes, { InferProps } from "prop-types";
 import { FontStyle } from "../../types/font";
 import { BorderStyle } from "../../types/border";
 import { FileDescription } from "../../misc/fileContext";
-import { Trace } from "../../types/trace";
 import { Plt } from "../../types/plt";
 import { PositionType } from "../../types/position";
 
@@ -82,8 +81,30 @@ export const BorderPropOpt = PropTypes.shape({
 });
 export const BorderProp = BorderPropOpt.isRequired;
 
-export const TraceProp = PropTypes.instanceOf(Trace).isRequired;
-export const TracePropOpt = PropTypes.instanceOf(Trace);
+export const TracePropOpt = PropTypes.shape({
+  name: StringProp,
+  axis: IntProp,
+  lineWidth: IntProp,
+  lineStyle: IntProp,
+  traceType: IntProp,
+  color: ColorProp,
+  pointType: IntProp,
+  pointSize: IntProp,
+  visible: BoolProp,
+  yPv: StringProp,
+  xPv: StringPropOpt,
+  bufferSize: IntPropOpt,
+  plotMode: IntPropOpt,
+  antiAlias: BoolPropOpt,
+  concatenateData: BoolPropOpt,
+  updateDelay: IntPropOpt,
+  updateMode: IntPropOpt,
+  archive: PropTypes.shape({
+    name: StringPropOpt,
+    url: StringPropOpt
+  })
+});
+export const TraceProp = TracePropOpt.isRequired;
 
 export const AxisPropOpt = PropTypes.shape({
   xAxis: BoolPropOpt,

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -2,7 +2,6 @@ import PropTypes, { InferProps } from "prop-types";
 import { FontStyle } from "../../types/font";
 import { BorderStyle } from "../../types/border";
 import { FileDescription } from "../../misc/fileContext";
-import { Plt } from "../../types/plt";
 import { PositionType } from "../../types/position";
 
 export type ExcludeNulls<T> = {
@@ -20,6 +19,12 @@ export const IntProp = PropTypes.number.isRequired;
 export const IntPropOpt = PropTypes.number;
 
 export const IntArrayPropOpt = PropTypes.arrayOf(PropTypes.number.isRequired);
+
+export const StringOrNumPropOpt = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number
+]);
+export const StringOrNumProp = StringOrNumPropOpt.isRequired;
 
 export const FloatProp = PropTypes.number.isRequired;
 export const FloatPropOpt = PropTypes.number;
@@ -86,7 +91,7 @@ export const TracePropOpt = PropTypes.shape({
   axis: IntProp,
   lineWidth: IntProp,
   lineStyle: IntProp,
-  traceType: IntProp,
+  traceType: StringOrNumProp,
   color: ColorProp,
   pointType: IntProp,
   pointSize: IntProp,
@@ -106,6 +111,9 @@ export const TracePropOpt = PropTypes.shape({
 });
 export const TraceProp = TracePropOpt.isRequired;
 
+export const TracesProp = PropTypes.arrayOf(TraceProp).isRequired;
+export const TracesPropOpt = PropTypes.arrayOf(TracePropOpt);
+
 export const AxisPropOpt = PropTypes.shape({
   xAxis: BoolPropOpt,
   color: ColorPropOpt,
@@ -122,14 +130,28 @@ export const AxisPropOpt = PropTypes.shape({
 });
 export const AxisProp = AxisPropOpt.isRequired;
 
-export const TracesProp = PropTypes.arrayOf(TraceProp).isRequired;
-export const TracesPropOpt = PropTypes.arrayOf(TracePropOpt);
-
 export const AxesProp = PropTypes.arrayOf(AxisProp).isRequired;
 export const AxesPropOpt = PropTypes.arrayOf(AxisPropOpt);
 
-export const PltProp = PropTypes.instanceOf(Plt).isRequired;
-export const PltPropOpt = PropTypes.instanceOf(Plt);
+export const PltPropOpt = PropTypes.shape({
+  title: StringProp,
+  axes: AxesProp,
+  pvlist: TracesProp,
+  backgroundColor: ColorProp,
+  foregroundColor: ColorProp,
+  scroll: BoolProp,
+  scrollStep: IntProp,
+  updatePeriod: IntProp,
+  bufferSize: IntProp,
+  start: StringProp,
+  end: StringProp,
+  showGrid: BoolProp,
+  titleFont: FontProp,
+  scaleFont: FontProp,
+  labelFont: FontProp,
+  legendFont: FontProp
+});
+export const PltProp = PltPropOpt.isRequired;
 
 export const FuncPropOpt = PropTypes.instanceOf(Function);
 export const FuncProp = FuncPropOpt.isRequired;
@@ -229,12 +251,6 @@ export const RulesProp = PropTypes.arrayOf(RulePropType.isRequired).isRequired;
 export const RulesPropOpt = PropTypes.arrayOf(RulePropType.isRequired);
 
 export const ScriptsPropOpt = PropTypes.arrayOf(ScriptPropType.isRequired);
-
-export const StringOrNumPropOpt = PropTypes.oneOfType([
-  PropTypes.string,
-  PropTypes.number
-]);
-export const StringOrNumProp = StringOrNumPropOpt.isRequired;
 
 export function ChoicePropOpt(
   options: string[]


### PR DESCRIPTION
Updates the Trace and Plt classes to be interfaces instead, due to redux toolkit errors. This now brings them in line with most of the other cs-web-lib types.