### PR TITLE
Automatic layout of a pixel placed screen for React-Grid-Layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.15",
+      "version": "0.10.16",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^7.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -720,7 +720,6 @@ describe("findWidgetById", () => {
   });
 
   test("returns undefined if tree is not an array", () => {
-    // @ts-expect-error intentional bad input
     expect(findWidgetById({} as any, "123")).toBeUndefined();
   });
 

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -16,7 +16,11 @@ import csReducer, {
   FullPvState,
   PvState,
   deviceComparator,
-  PvArrayResults
+  PvArrayResults,
+  findWidgetById,
+  fileDisplaySetGridLayout,
+  fileDisplaySetResponsiveLayout,
+  makeSelectWidgetPosition
 } from "./csState";
 import {
   DType,
@@ -296,22 +300,22 @@ describe("Selectors", () => {
   describe("selectPvStates", (): void => {
     it("returns appropriate values if PV present", (): void => {
       const results = selectPvStates(state, [pv1]);
-      const [pvState, effectivePv] = results[pv1];
-      expect(pvState).toEqual(pvState);
+      const [resultsPvState, effectivePv] = results[pv1];
+      expect(resultsPvState).toEqual(pvState);
       expect(effectivePv).toEqual(pv1);
     });
 
     it("returns correct effective PV name", (): void => {
       const results = selectPvStates(state, [pv2]);
-      const [pvState, effectivePv] = results[pv2];
-      expect(pvState).toBeUndefined();
+      const [resultsPvState, effectivePv] = results[pv2];
+      expect(resultsPvState).toBeUndefined();
       expect(effectivePv).toEqual(pv3);
     });
 
     it("returns appropriate values if PV not present", (): void => {
       const results = selectPvStates(state, ["not-a-pv"]);
-      const [pvState, shortName] = results["not-a-pv"];
-      expect(pvState).toBeUndefined();
+      const [resultsPvState, shortName] = results["not-a-pv"];
+      expect(resultsPvState).toBeUndefined();
       expect(shortName).toEqual("not-a-pv");
     });
   });
@@ -435,14 +439,360 @@ describe("Selectors", () => {
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
-      state.cs.fileCache["test.bob"] = contents;
 
-      expect(selectFile(state, "test.bob")).toEqual(contents);
+      const localState = {
+        ...state,
+        cs: {
+          ...state.cs,
+          fileCache: {
+            ...state.cs.fileCache,
+            "test.bob": contents
+          }
+        }
+      };
+
+      expect(selectFile(localState, "test.bob")).toEqual(contents);
     });
 
     it("returns undefined if device not in cache", (): void => {
       const localState = { ...state, cs: { ...state.cs, fileCache: {} } };
       expect(selectFile(localState, "test2.bob")).toBeUndefined();
     });
+  });
+});
+
+describe("fileDisplaySetGridLayout", () => {
+  const baseDisplay = {
+    id: "display1",
+    type: "displayGridLayout",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position: newAbsolutePosition("10", "10", "20", "20")
+      }
+    ],
+    position: newAbsolutePosition("0", "0", "100", "100")
+  };
+
+  const initialState: CsState = {
+    valueCache: {},
+    globalMacros: {},
+    subscriptions: {},
+    effectivePvNameMap: {},
+    deviceCache: {},
+    fileCache: {
+      "file.bob": baseDisplay as any
+    },
+    pvwsSettings: {}
+  };
+
+  test("applies grid layout properties and normalises child positions", () => {
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "display1",
+      gridLayout: [{ i: "child1", x: 0, y: 0, w: 2, h: 2 }],
+      gridLayoutColumns: 12,
+      gridCellMargins: [5, 5],
+      gridCellHeight: 30,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: false
+    });
+
+    const state = csReducer(initialState, action);
+    const display = state.fileCache["file.bob"];
+
+    expect(display.gridLayoutColumns).toBe(12);
+    expect(display.gridCellHeight).toBe(30);
+
+    const child = display?.children?.[0];
+    expect(child?.position).toMatchObject({
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    });
+  });
+
+  test("does nothing if display not found", () => {
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "missing",
+      gridLayout: [],
+      gridLayoutColumns: 12,
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = csReducer(initialState, action);
+    expect(state).toEqual(initialState);
+  });
+
+  test("does nothing if wrong display type", () => {
+    const badState: CsState = {
+      ...initialState,
+      fileCache: {
+        "file.bob": {
+          ...baseDisplay,
+          type: "shape" // wrong type
+        } as any
+      }
+    };
+
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "display1",
+      gridLayout: [],
+      gridLayoutColumns: 12,
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = csReducer(badState, action);
+    expect(state).toEqual(badState);
+  });
+});
+
+describe("fileDisplaySetResponsiveLayout", () => {
+  const baseDisplay = {
+    id: "display1",
+    type: "displayResponsive",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position: newAbsolutePosition("10", "10", "20", "20")
+      }
+    ],
+    position: newAbsolutePosition("0", "0", "100", "100")
+  };
+
+  const initialState: CsState = {
+    valueCache: {},
+    globalMacros: {},
+    subscriptions: {},
+    effectivePvNameMap: {},
+    deviceCache: {},
+    fileCache: {
+      "file.bob": baseDisplay as any
+    },
+    pvwsSettings: {}
+  };
+
+  test("applies responsive layout and updates child positions", () => {
+    const action = fileDisplaySetResponsiveLayout({
+      file: "file.bob",
+      displayId: "display1",
+      responsiveLayouts: { lg: [] },
+      responsiveColumns: { lg: 12 },
+      responsiveBreakpoints: { lg: 1200 },
+      gridCellMargins: [10, 10],
+      gridCellHeight: 50,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: false
+    });
+
+    const state = csReducer(initialState, action);
+    const display = state.fileCache["file.bob"];
+
+    expect(display.responsiveColumns.lg).toBe(12);
+    expect(display.gridCellHeight).toBe(50);
+
+    // parent width forced to 100%
+    expect(display.position.width).toBe("100%");
+
+    const child = display?.children?.[0];
+    expect(child?.position).toMatchObject({
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    });
+  });
+
+  test("does nothing if display type is wrong", () => {
+    const badState = {
+      ...initialState,
+      fileCache: {
+        "file.bob": { ...baseDisplay, type: "shape" } as any
+      }
+    };
+
+    const action = fileDisplaySetResponsiveLayout({
+      file: "file.bob",
+      displayId: "display1",
+      responsiveLayouts: {},
+      responsiveColumns: {},
+      responsiveBreakpoints: {},
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = csReducer(badState, action);
+    expect(state).toEqual(badState);
+  });
+});
+
+describe("makeSelectWidgetPosition", () => {
+  const position = newAbsolutePosition("1", "2", "3", "4");
+
+  const file = {
+    id: "root",
+    type: "display",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position
+      }
+    ]
+  };
+
+  const state = createRootStoreState({
+    valueCache: {},
+    globalMacros: {},
+    subscriptions: {},
+    effectivePvNameMap: {},
+    deviceCache: {},
+    fileCache: {
+      "file.bob": file as any
+    },
+    pvwsSettings: {}
+  });
+
+  test("returns widget position when found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "file.bob", "child1");
+
+    expect(result).toEqual(position);
+  });
+
+  test("returns undefined if widget not found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "file.bob", "missing");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined if file not found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "missing.bob", "child1");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("memoizes results (same inputs)", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result1 = selector(state, "file.bob", "child1");
+    const result2 = selector(state, "file.bob", "child1");
+
+    expect(result1).toBe(result2);
+  });
+});
+
+describe("findWidgetById", () => {
+  const makeWidget = (
+    id: string,
+    children?: WidgetDescription[]
+  ): WidgetDescription => ({
+    id,
+    type: "shape",
+    fileId: "file",
+    position: newAbsolutePosition("0", "0", "10", "10"),
+    children
+  });
+
+  test("returns undefined if tree is undefined", () => {
+    expect(findWidgetById(undefined, "123")).toBeUndefined();
+  });
+
+  test("returns undefined if tree is not an array", () => {
+    // @ts-expect-error intentional bad input
+    expect(findWidgetById({} as any, "123")).toBeUndefined();
+  });
+
+  test("finds a widget at root level", () => {
+    const tree = [makeWidget("1"), makeWidget("2")];
+
+    const result = findWidgetById(tree, "2");
+
+    expect(result?.id).toBe("2");
+  });
+
+  test("returns undefined if widget not found", () => {
+    const tree = [makeWidget("1"), makeWidget("2")];
+
+    const result = findWidgetById(tree, "999");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("finds a widget nested one level deep", () => {
+    const tree = [makeWidget("1", [makeWidget("1-1"), makeWidget("1-2")])];
+
+    const result = findWidgetById(tree, "1-2");
+
+    expect(result?.id).toBe("1-2");
+  });
+
+  test("finds a widget nested multiple levels deep", () => {
+    const tree = [makeWidget("1", [makeWidget("1-1", [makeWidget("1-1-1")])])];
+
+    const result = findWidgetById(tree, "1-1-1");
+
+    expect(result?.id).toBe("1-1-1");
+  });
+
+  test("returns first match if duplicate ids exist", () => {
+    const duplicate = makeWidget("dup");
+    const tree = [
+      makeWidget("1", [duplicate]),
+      makeWidget("2", [makeWidget("dup")])
+    ];
+
+    const result = findWidgetById(tree, "dup");
+
+    expect(result).toBe(duplicate); // ensures first match
+  });
+
+  test("skips invalid nodes safely", () => {
+    const tree = [
+      null as unknown as WidgetDescription,
+      makeWidget("1"),
+      undefined as unknown as WidgetDescription
+    ];
+
+    const result = findWidgetById(tree, "1");
+
+    expect(result?.id).toBe("1");
+  });
+
+  test("handles nodes without children", () => {
+    const tree = [makeWidget("1")];
+
+    const result = findWidgetById(tree, "1");
+
+    expect(result?.id).toBe("1");
+  });
+
+  test("handles empty children arrays", () => {
+    const tree = [makeWidget("1", [])];
+
+    const result = findWidgetById(tree, "1");
+
+    expect(result?.id).toBe("1");
   });
 });

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -54,6 +54,7 @@ const initialState: CsState = {
   deviceCache: {},
   fileCache: {
     "mySecondFile.bob": {
+      fileId: "mySecondFile.bob",
       id: "123",
       type: "ellipse",
       position: newAbsolutePosition("0", "0", "0", "0")
@@ -241,6 +242,7 @@ describe("FILE_CHANGED", (): void => {
   test("csReducer adds file to fileCache", (): void => {
     const contents: WidgetDescription = {
       id: "123",
+      fileId: "AShapeFile",
       type: "shape",
       position: newAbsolutePosition("0", "0", "0", "0")
     };
@@ -383,11 +385,13 @@ describe("Selectors", () => {
     it("returns false if string contents don't match", (): void => {
       const contents1: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
       const contents2: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("1", "0", "0", "0")
       };
@@ -397,12 +401,14 @@ describe("Selectors", () => {
     it("returns false if number of keys changed", (): void => {
       const contents1: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0"),
         backgroundColor: ColorUtils.TRANSPARENT
       };
       const contents2: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -413,6 +419,7 @@ describe("Selectors", () => {
     it("returns true if matches", (): void => {
       const contents: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };
@@ -424,6 +431,7 @@ describe("Selectors", () => {
     it("finds file in fileCache", (): void => {
       const contents: WidgetDescription = {
         id: "123",
+        fileId: "AShapeFile",
         type: "shape",
         position: newAbsolutePosition("0", "0", "0", "0")
       };

--- a/src/redux/csState.test.ts
+++ b/src/redux/csState.test.ts
@@ -6,22 +6,15 @@ import csReducer, {
   valueChanged,
   valuesChanged,
   unsubscribe,
-  fileChanged,
-  refreshFile,
   selectPvStates,
   pvStateComparator,
   selectDevice,
-  fileComparator,
-  selectFile,
   FullPvState,
   PvState,
   deviceComparator,
-  PvArrayResults,
-  findWidgetById,
-  fileDisplaySetGridLayout,
-  fileDisplaySetResponsiveLayout,
-  makeSelectWidgetPosition
+  PvArrayResults
 } from "./csState";
+import { findWidgetById } from "./slices/storeUtils";
 import {
   DType,
   dTypeGetAlarm,
@@ -41,7 +34,6 @@ import {
 } from "../testResources";
 import { WidgetDescription } from "../ui/widgets/createComponent";
 import { newAbsolutePosition } from "../types/position";
-import { ColorUtils } from "../types";
 
 const initialState: CsState = {
   valueCache: {
@@ -56,14 +48,6 @@ const initialState: CsState = {
   subscriptions: {},
   effectivePvNameMap: {},
   deviceCache: {},
-  fileCache: {
-    "mySecondFile.bob": {
-      fileId: "mySecondFile.bob",
-      id: "123",
-      type: "ellipse",
-      position: newAbsolutePosition("0", "0", "0", "0")
-    }
-  },
   pvwsSettings: {}
 };
 
@@ -242,38 +226,6 @@ test("handles initializers", (): void => {
   expect(state5.effectivePvNameMap["PV(1)"]).toEqual(undefined);
 });
 
-describe("FILE_CHANGED", (): void => {
-  test("csReducer adds file to fileCache", (): void => {
-    const contents: WidgetDescription = {
-      id: "123",
-      fileId: "AShapeFile",
-      type: "shape",
-      position: newAbsolutePosition("0", "0", "0", "0")
-    };
-    const fileName = "myfile.bob";
-    const action: ReturnType<typeof fileChanged> = {
-      type: "cs/fileChanged",
-      payload: { file: fileName, contents: contents }
-    };
-
-    const newState = csReducer(initialState, action);
-    expect(newState.fileCache[fileName]).toEqual(contents);
-  });
-});
-
-describe("REFRESH_FILE", (): void => {
-  test("csReducer deletes the file entry from fileCache", (): void => {
-    const fileName = "mySecondFile.bob";
-    const action: ReturnType<typeof refreshFile> = {
-      type: "cs/refreshFile",
-      payload: { file: fileName }
-    };
-
-    const newState = csReducer(initialState, action);
-    expect(newState.fileCache[fileName]).toBeUndefined();
-  });
-});
-
 describe("Selectors", () => {
   const pv1 = "pv1";
   const pv2 = "pv2";
@@ -291,7 +243,6 @@ describe("Selectors", () => {
     effectivePvNameMap: { pv1: "pv1", pv2: "pv3" },
     subscriptions: {},
     deviceCache: {},
-    fileCache: {},
     pvwsSettings: {}
   };
 
@@ -383,323 +334,6 @@ describe("Selectors", () => {
       const localState = { ...state, cs: { ...state.cs, deviceCache: {} } };
       expect(selectDevice(localState, "testDevice")).toBeUndefined();
     });
-  });
-
-  describe("fileComparator", (): void => {
-    it("returns false if string contents don't match", (): void => {
-      const contents1: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("0", "0", "0", "0")
-      };
-      const contents2: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("1", "0", "0", "0")
-      };
-      expect(fileComparator(contents1, contents2)).toBe(false);
-    });
-
-    it("returns false if number of keys changed", (): void => {
-      const contents1: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("0", "0", "0", "0"),
-        backgroundColor: ColorUtils.TRANSPARENT
-      };
-      const contents2: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("0", "0", "0", "0")
-      };
-
-      expect(fileComparator(contents1, contents2)).toBe(false);
-    });
-
-    it("returns true if matches", (): void => {
-      const contents: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("0", "0", "0", "0")
-      };
-      expect(fileComparator(contents, { ...contents })).toBe(true);
-    });
-  });
-
-  describe("selectFile", (): void => {
-    it("finds file in fileCache", (): void => {
-      const contents: WidgetDescription = {
-        id: "123",
-        fileId: "AShapeFile",
-        type: "shape",
-        position: newAbsolutePosition("0", "0", "0", "0")
-      };
-
-      const localState = {
-        ...state,
-        cs: {
-          ...state.cs,
-          fileCache: {
-            ...state.cs.fileCache,
-            "test.bob": contents
-          }
-        }
-      };
-
-      expect(selectFile(localState, "test.bob")).toEqual(contents);
-    });
-
-    it("returns undefined if device not in cache", (): void => {
-      const localState = { ...state, cs: { ...state.cs, fileCache: {} } };
-      expect(selectFile(localState, "test2.bob")).toBeUndefined();
-    });
-  });
-});
-
-describe("fileDisplaySetGridLayout", () => {
-  const baseDisplay = {
-    id: "display1",
-    type: "displayGridLayout",
-    fileId: "file",
-    children: [
-      {
-        id: "child1",
-        type: "shape",
-        position: newAbsolutePosition("10", "10", "20", "20")
-      }
-    ],
-    position: newAbsolutePosition("0", "0", "100", "100")
-  };
-
-  const initialState: CsState = {
-    valueCache: {},
-    globalMacros: {},
-    subscriptions: {},
-    effectivePvNameMap: {},
-    deviceCache: {},
-    fileCache: {
-      "file.bob": baseDisplay as any
-    },
-    pvwsSettings: {}
-  };
-
-  test("applies grid layout properties and normalises child positions", () => {
-    const action = fileDisplaySetGridLayout({
-      file: "file.bob",
-      displayId: "display1",
-      gridLayout: [{ i: "child1", x: 0, y: 0, w: 2, h: 2 }],
-      gridLayoutColumns: 12,
-      gridCellMargins: [5, 5],
-      gridCellHeight: 30,
-      gridCellDragEnabled: true,
-      gridCellResizeEnabled: false
-    });
-
-    const state = csReducer(initialState, action);
-    const display = state.fileCache["file.bob"];
-
-    expect(display.gridLayoutColumns).toBe(12);
-    expect(display.gridCellHeight).toBe(30);
-
-    const child = display?.children?.[0];
-    expect(child?.position).toMatchObject({
-      x: "0",
-      y: "0",
-      width: "100%",
-      height: "100%"
-    });
-  });
-
-  test("does nothing if display not found", () => {
-    const action = fileDisplaySetGridLayout({
-      file: "file.bob",
-      displayId: "missing",
-      gridLayout: [],
-      gridLayoutColumns: 12,
-      gridCellMargins: [0, 0],
-      gridCellHeight: 10,
-      gridCellDragEnabled: true,
-      gridCellResizeEnabled: true
-    });
-
-    const state = csReducer(initialState, action);
-    expect(state).toEqual(initialState);
-  });
-
-  test("does nothing if wrong display type", () => {
-    const badState: CsState = {
-      ...initialState,
-      fileCache: {
-        "file.bob": {
-          ...baseDisplay,
-          type: "shape" // wrong type
-        } as any
-      }
-    };
-
-    const action = fileDisplaySetGridLayout({
-      file: "file.bob",
-      displayId: "display1",
-      gridLayout: [],
-      gridLayoutColumns: 12,
-      gridCellMargins: [0, 0],
-      gridCellHeight: 10,
-      gridCellDragEnabled: true,
-      gridCellResizeEnabled: true
-    });
-
-    const state = csReducer(badState, action);
-    expect(state).toEqual(badState);
-  });
-});
-
-describe("fileDisplaySetResponsiveLayout", () => {
-  const baseDisplay = {
-    id: "display1",
-    type: "displayResponsive",
-    fileId: "file",
-    children: [
-      {
-        id: "child1",
-        type: "shape",
-        position: newAbsolutePosition("10", "10", "20", "20")
-      }
-    ],
-    position: newAbsolutePosition("0", "0", "100", "100")
-  };
-
-  const initialState: CsState = {
-    valueCache: {},
-    globalMacros: {},
-    subscriptions: {},
-    effectivePvNameMap: {},
-    deviceCache: {},
-    fileCache: {
-      "file.bob": baseDisplay as any
-    },
-    pvwsSettings: {}
-  };
-
-  test("applies responsive layout and updates child positions", () => {
-    const action = fileDisplaySetResponsiveLayout({
-      file: "file.bob",
-      displayId: "display1",
-      responsiveLayouts: { lg: [] },
-      responsiveColumns: { lg: 12 },
-      responsiveBreakpoints: { lg: 1200 },
-      gridCellMargins: [10, 10],
-      gridCellHeight: 50,
-      gridCellDragEnabled: true,
-      gridCellResizeEnabled: false
-    });
-
-    const state = csReducer(initialState, action);
-    const display = state.fileCache["file.bob"];
-
-    expect(display.responsiveColumns.lg).toBe(12);
-    expect(display.gridCellHeight).toBe(50);
-
-    // parent width forced to 100%
-    expect(display.position.width).toBe("100%");
-
-    const child = display?.children?.[0];
-    expect(child?.position).toMatchObject({
-      x: "0",
-      y: "0",
-      width: "100%",
-      height: "100%"
-    });
-  });
-
-  test("does nothing if display type is wrong", () => {
-    const badState = {
-      ...initialState,
-      fileCache: {
-        "file.bob": { ...baseDisplay, type: "shape" } as any
-      }
-    };
-
-    const action = fileDisplaySetResponsiveLayout({
-      file: "file.bob",
-      displayId: "display1",
-      responsiveLayouts: {},
-      responsiveColumns: {},
-      responsiveBreakpoints: {},
-      gridCellMargins: [0, 0],
-      gridCellHeight: 10,
-      gridCellDragEnabled: true,
-      gridCellResizeEnabled: true
-    });
-
-    const state = csReducer(badState, action);
-    expect(state).toEqual(badState);
-  });
-});
-
-describe("makeSelectWidgetPosition", () => {
-  const position = newAbsolutePosition("1", "2", "3", "4");
-
-  const file = {
-    id: "root",
-    type: "display",
-    fileId: "file",
-    children: [
-      {
-        id: "child1",
-        type: "shape",
-        position
-      }
-    ]
-  };
-
-  const state = createRootStoreState({
-    valueCache: {},
-    globalMacros: {},
-    subscriptions: {},
-    effectivePvNameMap: {},
-    deviceCache: {},
-    fileCache: {
-      "file.bob": file as any
-    },
-    pvwsSettings: {}
-  });
-
-  test("returns widget position when found", () => {
-    const selector = makeSelectWidgetPosition();
-
-    const result = selector(state, "file.bob", "child1");
-
-    expect(result).toEqual(position);
-  });
-
-  test("returns undefined if widget not found", () => {
-    const selector = makeSelectWidgetPosition();
-
-    const result = selector(state, "file.bob", "missing");
-
-    expect(result).toBeUndefined();
-  });
-
-  test("returns undefined if file not found", () => {
-    const selector = makeSelectWidgetPosition();
-
-    const result = selector(state, "missing.bob", "child1");
-
-    expect(result).toBeUndefined();
-  });
-
-  test("memoizes results (same inputs)", () => {
-    const selector = makeSelectWidgetPosition();
-
-    const result1 = selector(state, "file.bob", "child1");
-    const result2 = selector(state, "file.bob", "child1");
-
-    expect(result1).toBe(result2);
   });
 });
 

--- a/src/redux/csState.ts
+++ b/src/redux/csState.ts
@@ -4,7 +4,7 @@ import { mergeDType, DType } from "../types/dtypes";
 import { WidgetDescription } from "../ui/widgets/createComponent";
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { SubscriptionType } from "../connection";
-import { Layout } from "react-grid-layout";
+import { Breakpoints, Layout, ResponsiveLayouts } from "react-grid-layout";
 import { Position } from "../types/position";
 
 export const initialCsState: CsState = {
@@ -209,7 +209,7 @@ const csSlice = createSlice({
       state.fileCache[file] = contents;
     },
 
-    fileDisplaySetRGLayout(
+    fileDisplaySetGridLayout(
       state,
       action: PayloadAction<{
         file: string;
@@ -239,13 +239,68 @@ const csSlice = createSlice({
         return;
       }
 
-      // set grid layout items
+      // set grid layout props
       display["gridLayout"] = gridLayout;
       display["gridCellHeight"] = gridCellHeight;
       display["gridCellMargins"] = gridCellMargins;
       display["gridLayoutColumns"] = gridLayoutColumns;
       display["gridCellDragEnabled"] = gridCellDragEnabled;
       display["gridCellResizeEnabled"] = gridCellResizeEnabled;
+
+      // Set child positions, as position is now defined in the display layout
+      display?.children?.forEach(c => {
+        if (c.position) {
+          c.position["x"] = "0";
+          c.position["y"] = "0";
+          c.position["width"] = "100%";
+          c.position["height"] = "100%";
+        }
+      });
+    },
+
+    fileDisplaySetResponsiveLayout(
+      state,
+      action: PayloadAction<{
+        file: string;
+        displayId: string;
+        responsiveLayouts: ResponsiveLayouts<string>;
+        responsiveColumns: Breakpoints<string>;
+        responsiveBreakpoints: Breakpoints<string>;
+        gridCellMargins: [number, number];
+        gridCellHeight: number;
+        gridCellDragEnabled: boolean;
+        gridCellResizeEnabled: boolean;
+      }>
+    ) {
+      log.debug(action);
+      const {
+        file,
+        displayId,
+        responsiveLayouts,
+        responsiveColumns,
+        responsiveBreakpoints,
+        gridCellMargins,
+        gridCellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      } = action.payload;
+      const fileDescription = state.fileCache[file];
+      const display = findWidgetById([fileDescription], displayId);
+      if (!display || display.type !== "displayResponsive") {
+        return;
+      }
+
+      // set responsive layout props
+      display["responsiveLayouts"] = responsiveLayouts;
+      display["responsiveColumns"] = responsiveColumns;
+      display["responsiveBreakpoints"] = responsiveBreakpoints;
+      display["gridCellHeight"] = gridCellHeight;
+      display["gridCellMargins"] = gridCellMargins;
+      display["gridCellDragEnabled"] = gridCellDragEnabled;
+      display["gridCellResizeEnabled"] = gridCellResizeEnabled;
+      if (display.position) {
+        display.position["width"] = "100%";
+      }
 
       // Set child positions, as position is now defined in the display layout
       display?.children?.forEach(c => {
@@ -286,7 +341,8 @@ export const {
   deviceQueried,
   queryDevice,
   fileChanged,
-  fileDisplaySetRGLayout,
+  fileDisplaySetGridLayout,
+  fileDisplaySetResponsiveLayout,
   refreshFile
 } = csSlice.actions;
 export default csSlice.reducer;

--- a/src/redux/csState.ts
+++ b/src/redux/csState.ts
@@ -80,7 +80,14 @@ function updateValueCache(
 ): void {
   const { pvName, value } = action.payload;
   const mergedValue = mergeDType(valueCache[pvName]?.value, value);
-  valueCache[pvName] = { ...valueCache[pvName], value: mergedValue };
+
+  const existing = valueCache[pvName] ?? {
+    connected: false,
+    readonly: true,
+    initializingPvName: pvName
+  };
+
+  valueCache[pvName] = { ...existing, value: mergedValue };
 }
 
 const csSlice = createSlice({

--- a/src/redux/csState.ts
+++ b/src/redux/csState.ts
@@ -1,11 +1,8 @@
 import log from "loglevel";
 import { MacroMap } from "../types/macros";
 import { mergeDType, DType } from "../types/dtypes";
-import { WidgetDescription } from "../ui/widgets/createComponent";
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { SubscriptionType } from "../connection";
-import { Breakpoints, Layout, ResponsiveLayouts } from "react-grid-layout";
-import { Position } from "../types/position";
 
 export const initialCsState: CsState = {
   valueCache: {},
@@ -13,7 +10,6 @@ export const initialCsState: CsState = {
   effectivePvNameMap: {},
   subscriptions: {},
   deviceCache: {},
-  fileCache: {},
   pvwsSettings: {}
 };
 
@@ -47,10 +43,6 @@ export interface DeviceCache {
   [deviceName: string]: DType;
 }
 
-export interface FileCache {
-  [fileName: string]: WidgetDescription;
-}
-
 export interface PvwsSettings {
   pvwsHost?: string;
 }
@@ -66,7 +58,6 @@ export interface CsState {
   globalMacros: MacroMap;
   subscriptions: Subscriptions;
   deviceCache: DeviceCache;
-  fileCache: FileCache;
   pvwsSettings: PvwsSettings;
 }
 
@@ -205,130 +196,10 @@ const csSlice = createSlice({
 
     queryDevice(_state, _action: PayloadAction<{ device: string }>) {
       // intentionally empty — handled by listener middleware
-    },
-
-    fileChanged(
-      state,
-      action: PayloadAction<{ file: string; contents: WidgetDescription }>
-    ) {
-      log.debug(action);
-      const { file, contents } = action.payload;
-      state.fileCache[file] = contents;
-    },
-
-    fileDisplaySetGridLayout(
-      state,
-      action: PayloadAction<{
-        file: string;
-        displayId: string;
-        gridLayout: Layout;
-        gridLayoutColumns: number;
-        gridCellMargins: [number, number];
-        gridCellHeight: number;
-        gridCellDragEnabled: boolean;
-        gridCellResizeEnabled: boolean;
-      }>
-    ) {
-      log.debug(action);
-      const {
-        file,
-        displayId,
-        gridLayout,
-        gridLayoutColumns,
-        gridCellMargins,
-        gridCellHeight,
-        gridCellDragEnabled,
-        gridCellResizeEnabled
-      } = action.payload;
-      const fileDescription = state.fileCache[file];
-      const display = findWidgetById([fileDescription], displayId);
-      if (!display || display.type !== "displayGridLayout") {
-        return;
-      }
-
-      // set grid layout props
-      display["gridLayout"] = gridLayout;
-      display["gridCellHeight"] = gridCellHeight;
-      display["gridCellMargins"] = gridCellMargins;
-      display["gridLayoutColumns"] = gridLayoutColumns;
-      display["gridCellDragEnabled"] = gridCellDragEnabled;
-      display["gridCellResizeEnabled"] = gridCellResizeEnabled;
-
-      // Set child positions, as position is now defined in the display layout
-      display?.children?.forEach(c => {
-        if (c.position) {
-          c.position["x"] = "0";
-          c.position["y"] = "0";
-          c.position["width"] = "100%";
-          c.position["height"] = "100%";
-        }
-      });
-    },
-
-    fileDisplaySetResponsiveLayout(
-      state,
-      action: PayloadAction<{
-        file: string;
-        displayId: string;
-        responsiveLayouts: ResponsiveLayouts<string>;
-        responsiveColumns: Breakpoints<string>;
-        responsiveBreakpoints: Breakpoints<string>;
-        gridCellMargins: [number, number];
-        gridCellHeight: number;
-        gridCellDragEnabled: boolean;
-        gridCellResizeEnabled: boolean;
-      }>
-    ) {
-      log.debug(action);
-      const {
-        file,
-        displayId,
-        responsiveLayouts,
-        responsiveColumns,
-        responsiveBreakpoints,
-        gridCellMargins,
-        gridCellHeight,
-        gridCellDragEnabled,
-        gridCellResizeEnabled
-      } = action.payload;
-      const fileDescription = state.fileCache[file];
-      const display = findWidgetById([fileDescription], displayId);
-      if (!display || display.type !== "displayResponsive") {
-        return;
-      }
-
-      // set responsive layout props
-      display["responsiveLayouts"] = responsiveLayouts;
-      display["responsiveColumns"] = responsiveColumns;
-      display["responsiveBreakpoints"] = responsiveBreakpoints;
-      display["gridCellHeight"] = gridCellHeight;
-      display["gridCellMargins"] = gridCellMargins;
-      display["gridCellDragEnabled"] = gridCellDragEnabled;
-      display["gridCellResizeEnabled"] = gridCellResizeEnabled;
-      if (display.position) {
-        display.position["width"] = "100%";
-      }
-
-      // Set child positions, as position is now defined in the display layout
-      display?.children?.forEach(c => {
-        if (c.position) {
-          c.position["x"] = "0";
-          c.position["y"] = "0";
-          c.position["width"] = "100%";
-          c.position["height"] = "100%";
-        }
-      });
-    },
-
-    refreshFile(state, action: PayloadAction<{ file: string }>) {
-      log.debug(action);
-      const { file } = action.payload;
-      delete state.fileCache[file];
     }
   },
   selectors: {
     selectDeviceCache: state => state.deviceCache,
-    selectFileCache: state => state.fileCache,
     selectEffectivePvNameMap: state => state.effectivePvNameMap,
     selectValueCache: state => state.valueCache,
     selectGlobalMacros: state => state.globalMacros,
@@ -346,16 +217,11 @@ export const {
   unsubscribe,
   writePv,
   deviceQueried,
-  queryDevice,
-  fileChanged,
-  fileDisplaySetGridLayout,
-  fileDisplaySetResponsiveLayout,
-  refreshFile
+  queryDevice
 } = csSlice.actions;
 export default csSlice.reducer;
 export const {
   selectDeviceCache,
-  selectFileCache,
   selectEffectivePvNameMap,
   selectValueCache,
   selectGlobalMacros,
@@ -371,28 +237,6 @@ export const selectDevice = createSelector(
   [selectDeviceCache, (_state, deviceId: string) => deviceId],
   (deviceCache, deviceId) => deviceCache[deviceId]
 );
-
-export const selectFile = createSelector(
-  [selectFileCache, (_state, fileId: string) => fileId],
-  (fileCache, fileId) => fileCache[fileId]
-);
-
-/**
- * This selector factory provides an alternative means for a widget to get its
- * position props. Generally the <Widget> wrapper should manage position and the
- * useContainerWidth hook should be used to get a measured width and height.
- * But in some rare situations these props need be be known before first render
- * and are not expected to change, for example through a react grid layout resize.
- * @returns A new selector that gets the widget position properties
- */
-export const makeSelectWidgetPosition = () =>
-  createSelector(
-    [selectFile, (_state: any, _fileId: string, widgetId: string) => widgetId],
-    (file, widgetId) =>
-      file
-        ? (findWidgetById([file], widgetId)?.position as Position | undefined)
-        : undefined
-  );
 
 export const selectPvStates = createSelector(
   [
@@ -411,27 +255,6 @@ export const selectPvStates = createSelector(
     return results;
   }
 );
-
-export const fileComparator = (
-  before: WidgetDescription,
-  after: WidgetDescription
-): boolean => {
-  if (!before || !after) {
-    return false;
-  }
-  if (Object.keys(before).length !== Object.keys(after).length) {
-    return false;
-  }
-  if (before.children?.length !== after.children?.length) {
-    return false;
-  }
-  // Can't compare objects directly because they are in different memory locations
-  // But we can compare strings
-  if (JSON.stringify(before) !== JSON.stringify(after)) {
-    return false;
-  }
-  return true;
-};
 
 /* Used for preventing re-rendering if the results are equivalent.
    Note that if the state for a particular PV hasn't changed, we will
@@ -474,28 +297,4 @@ export const deviceComparator = (before: DType, after: DType): boolean => {
     return false;
   }
   return true;
-};
-
-/**
- * Find an item in a tree by it's id.
- * @param tree The widget hierarchy
- * @param id The id of the widget to find.
- * @returns The matching widget description or undefined
- */
-export const findWidgetById = (
-  tree: WidgetDescription[] | undefined,
-  id: string
-): WidgetDescription | undefined => {
-  if (!Array.isArray(tree)) return undefined;
-
-  for (const node of tree) {
-    if (!node || typeof node !== "object") continue;
-
-    if (node.id === id) return node;
-
-    const found = findWidgetById(node.children, id);
-    if (found) return found;
-  }
-
-  return undefined;
 };

--- a/src/redux/csState.ts
+++ b/src/redux/csState.ts
@@ -4,6 +4,8 @@ import { mergeDType, DType } from "../types/dtypes";
 import { WidgetDescription } from "../ui/widgets/createComponent";
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { SubscriptionType } from "../connection";
+import { Layout } from "react-grid-layout";
+import { Position } from "../types/position";
 
 export const initialCsState: CsState = {
   valueCache: {},
@@ -207,6 +209,55 @@ const csSlice = createSlice({
       state.fileCache[file] = contents;
     },
 
+    fileDisplaySetRGLayout(
+      state,
+      action: PayloadAction<{
+        file: string;
+        displayId: string;
+        gridLayout: Layout;
+        gridLayoutColumns: number;
+        gridCellMargins: [number, number];
+        gridCellHeight: number;
+        gridCellDragEnabled: boolean;
+        gridCellResizeEnabled: boolean;
+      }>
+    ) {
+      log.debug(action);
+      const {
+        file,
+        displayId,
+        gridLayout,
+        gridLayoutColumns,
+        gridCellMargins,
+        gridCellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      } = action.payload;
+      const fileDescription = state.fileCache[file];
+      const display = findWidgetById([fileDescription], displayId);
+      if (!display || display.type !== "displayGridLayout") {
+        return;
+      }
+
+      // set grid layout items
+      display["gridLayout"] = gridLayout;
+      display["gridCellHeight"] = gridCellHeight;
+      display["gridCellMargins"] = gridCellMargins;
+      display["gridLayoutColumns"] = gridLayoutColumns;
+      display["gridCellDragEnabled"] = gridCellDragEnabled;
+      display["gridCellResizeEnabled"] = gridCellResizeEnabled;
+
+      // Set child positions, as position is now defined in the display layout
+      display?.children?.forEach(c => {
+        if (c.position) {
+          c.position["x"] = "0";
+          c.position["y"] = "0";
+          c.position["width"] = "100%";
+          c.position["height"] = "100%";
+        }
+      });
+    },
+
     refreshFile(state, action: PayloadAction<{ file: string }>) {
       log.debug(action);
       const { file } = action.payload;
@@ -235,6 +286,7 @@ export const {
   deviceQueried,
   queryDevice,
   fileChanged,
+  fileDisplaySetRGLayout,
   refreshFile
 } = csSlice.actions;
 export default csSlice.reducer;
@@ -261,6 +313,23 @@ export const selectFile = createSelector(
   [selectFileCache, (_state, fileId: string) => fileId],
   (fileCache, fileId) => fileCache[fileId]
 );
+
+/**
+ * This selector factory provides an alternative means for a widget to get its
+ * position props. Generally the <Widget> wrapper should manage position and the
+ * useContainerWidth hook should be used to get a measured width and height.
+ * But in some rare situations these props need be be known before first render
+ * and are not expected to change, for example through a react grid layout resize.
+ * @returns A new selector that gets the widget position properties
+ */
+export const makeSelectWidgetPosition = () =>
+  createSelector(
+    [selectFile, (_state: any, _fileId: string, widgetId: string) => widgetId],
+    (file, widgetId) =>
+      file
+        ? (findWidgetById([file], widgetId)?.position as Position | undefined)
+        : undefined
+  );
 
 export const selectPvStates = createSelector(
   [
@@ -342,4 +411,28 @@ export const deviceComparator = (before: DType, after: DType): boolean => {
     return false;
   }
   return true;
+};
+
+/**
+ * Find an item in a tree by it's id.
+ * @param tree The widget hierarchy
+ * @param id The id of the widget to find.
+ * @returns The matching widget description or undefined
+ */
+export const findWidgetById = (
+  tree: WidgetDescription[] | undefined,
+  id: string
+): WidgetDescription | undefined => {
+  if (!Array.isArray(tree)) return undefined;
+
+  for (const node of tree) {
+    if (!node || typeof node !== "object") continue;
+
+    if (node.id === id) return node;
+
+    const found = findWidgetById(node.children, id);
+    if (found) return found;
+  }
+
+  return undefined;
 };

--- a/src/redux/slices/fileCacheSlice.test.ts
+++ b/src/redux/slices/fileCacheSlice.test.ts
@@ -1,0 +1,358 @@
+import { createRootStoreState } from "../../testResources";
+import { ColorUtils } from "../../types";
+import { newAbsolutePosition } from "../../types/position";
+import { WidgetDescription } from "../../ui/widgets/createComponent";
+import fileCacheReducer, {
+  FileCacheState,
+  fileChanged,
+  fileComparator,
+  fileDisplaySetGridLayout,
+  fileDisplaySetResponsiveLayout,
+  makeSelectWidgetPosition,
+  refreshFile,
+  selectFile
+} from "./fileCacheSlice";
+
+const initialState: FileCacheState = {
+  fileCache: {
+    "mySecondFile.bob": {
+      fileId: "mySecondFile.bob",
+      id: "123",
+      type: "ellipse",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    }
+  }
+};
+
+describe("fileDisplaySetResponsiveLayout", () => {
+  const baseDisplay = {
+    id: "display1",
+    type: "displayResponsive",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position: newAbsolutePosition("10", "10", "20", "20")
+      }
+    ],
+    position: newAbsolutePosition("0", "0", "100", "100")
+  };
+
+  const initialState: FileCacheState = {
+    fileCache: {
+      "file.bob": baseDisplay as any
+    }
+  };
+
+  test("applies responsive layout and updates child positions", () => {
+    const action = fileDisplaySetResponsiveLayout({
+      file: "file.bob",
+      displayId: "display1",
+      responsiveLayouts: { lg: [] },
+      responsiveColumns: { lg: 12 },
+      responsiveBreakpoints: { lg: 1200 },
+      gridCellMargins: [10, 10],
+      gridCellHeight: 50,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: false
+    });
+
+    const state = fileCacheReducer(initialState, action);
+    const display = state.fileCache["file.bob"];
+
+    expect(display.responsiveColumns.lg).toBe(12);
+    expect(display.gridCellHeight).toBe(50);
+
+    // parent width forced to 100%
+    expect(display.position.width).toBe("100%");
+
+    const child = display?.children?.[0];
+    expect(child?.position).toMatchObject({
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    });
+  });
+
+  test("does nothing if display type is wrong", () => {
+    const badState = {
+      ...initialState,
+      fileCache: {
+        "file.bob": { ...baseDisplay, type: "shape" } as any
+      }
+    };
+
+    const action = fileDisplaySetResponsiveLayout({
+      file: "file.bob",
+      displayId: "display1",
+      responsiveLayouts: {},
+      responsiveColumns: {},
+      responsiveBreakpoints: {},
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = fileCacheReducer(badState, action);
+    expect(state).toEqual(badState);
+  });
+});
+
+describe("fileDisplaySetGridLayout", () => {
+  const baseDisplay = {
+    id: "display1",
+    type: "displayGridLayout",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position: newAbsolutePosition("10", "10", "20", "20")
+      }
+    ],
+    position: newAbsolutePosition("0", "0", "100", "100")
+  };
+
+  const initialState: FileCacheState = {
+    fileCache: {
+      "file.bob": baseDisplay as any
+    }
+  };
+
+  test("applies grid layout properties and normalises child positions", () => {
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "display1",
+      gridLayout: [{ i: "child1", x: 0, y: 0, w: 2, h: 2 }],
+      gridLayoutColumns: 12,
+      gridCellMargins: [5, 5],
+      gridCellHeight: 30,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: false
+    });
+
+    const state = fileCacheReducer(initialState, action);
+    const display = state.fileCache["file.bob"];
+
+    expect(display.gridLayoutColumns).toBe(12);
+    expect(display.gridCellHeight).toBe(30);
+
+    const child = display?.children?.[0];
+    expect(child?.position).toMatchObject({
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    });
+  });
+
+  test("does nothing if display not found", () => {
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "missing",
+      gridLayout: [],
+      gridLayoutColumns: 12,
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = fileCacheReducer(initialState, action);
+    expect(state).toEqual(initialState);
+  });
+
+  test("does nothing if wrong display type", () => {
+    const badState: FileCacheState = {
+      ...initialState,
+      fileCache: {
+        "file.bob": {
+          ...baseDisplay,
+          type: "shape" // wrong type
+        } as any
+      }
+    };
+
+    const action = fileDisplaySetGridLayout({
+      file: "file.bob",
+      displayId: "display1",
+      gridLayout: [],
+      gridLayoutColumns: 12,
+      gridCellMargins: [0, 0],
+      gridCellHeight: 10,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    });
+
+    const state = fileCacheReducer(badState, action);
+    expect(state).toEqual(badState);
+  });
+});
+
+describe("FILE_CHANGED", (): void => {
+  test("csReducer adds file to fileCache", (): void => {
+    const contents: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+    const fileName = "myfile.bob";
+    const action: ReturnType<typeof fileChanged> = {
+      type: "fileCache/fileChanged",
+      payload: { file: fileName, contents: contents }
+    };
+
+    const newState = fileCacheReducer(initialState, action);
+    expect(newState.fileCache[fileName]).toEqual(contents);
+  });
+});
+
+describe("REFRESH_FILE", (): void => {
+  test("csReducer deletes the file entry from fileCache", (): void => {
+    const fileName = "mySecondFile.bob";
+    const action: ReturnType<typeof refreshFile> = {
+      type: "fileCache/refreshFile",
+      payload: { file: fileName }
+    };
+
+    const newState = fileCacheReducer(initialState, action);
+    expect(newState.fileCache[fileName]).toBeUndefined();
+  });
+});
+
+describe("selectFile", (): void => {
+  const state = createRootStoreState(undefined, undefined, initialState);
+
+  it("finds file in fileCache", (): void => {
+    const contents: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+
+    const localState = {
+      ...state,
+      fileCache: {
+        ...state.cs,
+        fileCache: {
+          ...state.fileCache.fileCache,
+          "test.bob": contents
+        }
+      }
+    };
+
+    expect(selectFile(localState, "test.bob")).toEqual(contents);
+  });
+
+  it("returns undefined if device not in cache", (): void => {
+    const localState = { ...state, fileCache: { ...state.cs, fileCache: {} } };
+    expect(selectFile(localState, "test2.bob")).toBeUndefined();
+  });
+});
+
+describe("makeSelectWidgetPosition", () => {
+  const position = newAbsolutePosition("1", "2", "3", "4");
+
+  const file = {
+    id: "root",
+    type: "display",
+    fileId: "file",
+    children: [
+      {
+        id: "child1",
+        type: "shape",
+        position
+      }
+    ]
+  };
+
+  const state = createRootStoreState(undefined, undefined, {
+    fileCache: {
+      "file.bob": file as any
+    }
+  });
+
+  test("returns widget position when found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "file.bob", "child1");
+
+    expect(result).toEqual(position);
+  });
+
+  test("returns undefined if widget not found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "file.bob", "missing");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined if file not found", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result = selector(state, "missing.bob", "child1");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("memoizes results (same inputs)", () => {
+    const selector = makeSelectWidgetPosition();
+
+    const result1 = selector(state, "file.bob", "child1");
+    const result2 = selector(state, "file.bob", "child1");
+
+    expect(result1).toBe(result2);
+  });
+});
+
+describe("fileComparator", (): void => {
+  it("returns false if string contents don't match", (): void => {
+    const contents1: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+    const contents2: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("1", "0", "0", "0")
+    };
+    expect(fileComparator(contents1, contents2)).toBe(false);
+  });
+
+  it("returns false if number of keys changed", (): void => {
+    const contents1: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0"),
+      backgroundColor: ColorUtils.TRANSPARENT
+    };
+    const contents2: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+
+    expect(fileComparator(contents1, contents2)).toBe(false);
+  });
+
+  it("returns true if matches", (): void => {
+    const contents: WidgetDescription = {
+      id: "123",
+      fileId: "AShapeFile",
+      type: "shape",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+    expect(fileComparator(contents, { ...contents })).toBe(true);
+  });
+});

--- a/src/redux/slices/fileCacheSlice.ts
+++ b/src/redux/slices/fileCacheSlice.ts
@@ -1,0 +1,172 @@
+// fileCacheSlice.ts
+import { createSlice, PayloadAction, createSelector } from "@reduxjs/toolkit";
+import { WidgetDescription } from "../../ui/widgets/createComponent";
+import { findWidgetById } from "./storeUtils";
+import { Position } from "../../types";
+
+export interface FileCache {
+  [fileName: string]: WidgetDescription;
+}
+
+export interface FileCacheState {
+  fileCache: FileCache;
+}
+
+const initialState: FileCacheState = {
+  fileCache: {}
+};
+
+const fileCacheSlice = createSlice({
+  name: "fileCache",
+  initialState,
+  reducers: {
+    fileChanged(
+      state,
+      action: PayloadAction<{ file: string; contents: WidgetDescription }>
+    ) {
+      const { file, contents } = action.payload;
+      state.fileCache[file] = contents;
+    },
+
+    refreshFile(state, action: PayloadAction<{ file: string }>) {
+      delete state.fileCache[action.payload.file];
+    },
+
+    fileDisplaySetGridLayout(state, action) {
+      const {
+        file,
+        displayId,
+        gridLayout,
+        gridLayoutColumns,
+        gridCellMargins,
+        gridCellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      } = action.payload;
+
+      const fileDescription = state.fileCache[file];
+      const display = findWidgetById([fileDescription], displayId);
+
+      if (!display || display.type !== "displayGridLayout") return;
+
+      display.gridLayout = gridLayout;
+      display.gridCellHeight = gridCellHeight;
+      display.gridCellMargins = gridCellMargins;
+      display.gridLayoutColumns = gridLayoutColumns;
+      display.gridCellDragEnabled = gridCellDragEnabled;
+      display.gridCellResizeEnabled = gridCellResizeEnabled;
+
+      display.children?.forEach(c => {
+        if (c.position) {
+          c.position = {
+            ...c.position,
+            x: "0",
+            y: "0",
+            width: "100%",
+            height: "100%"
+          };
+        }
+      });
+    },
+
+    fileDisplaySetResponsiveLayout(state, action) {
+      const {
+        file,
+        displayId,
+        responsiveLayouts,
+        responsiveColumns,
+        responsiveBreakpoints,
+        gridCellMargins,
+        gridCellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      } = action.payload;
+
+      const fileDescription = state.fileCache[file];
+      const display = findWidgetById([fileDescription], displayId);
+
+      if (!display || display.type !== "displayResponsive") return;
+
+      display.responsiveLayouts = responsiveLayouts;
+      display.responsiveColumns = responsiveColumns;
+      display.responsiveBreakpoints = responsiveBreakpoints;
+      display.gridCellHeight = gridCellHeight;
+      display.gridCellMargins = gridCellMargins;
+      display.gridCellDragEnabled = gridCellDragEnabled;
+      display.gridCellResizeEnabled = gridCellResizeEnabled;
+
+      if (display.position) {
+        display.position.width = "100%";
+      }
+
+      display.children?.forEach(c => {
+        if (c.position) {
+          c.position = {
+            ...c.position,
+            x: "0",
+            y: "0",
+            width: "100%",
+            height: "100%"
+          };
+        }
+      });
+    }
+  },
+  selectors: {
+    selectFileCache: state => state.fileCache
+  }
+});
+
+export const {
+  fileChanged,
+  refreshFile,
+  fileDisplaySetGridLayout,
+  fileDisplaySetResponsiveLayout
+} = fileCacheSlice.actions;
+
+export default fileCacheSlice.reducer;
+
+export const { selectFileCache } = fileCacheSlice.selectors;
+
+export const selectFile = createSelector(
+  [selectFileCache, (_state, fileId: string) => fileId],
+  (fileCache, fileId) => fileCache[fileId]
+);
+
+export const fileComparator = (
+  before: WidgetDescription,
+  after: WidgetDescription
+): boolean => {
+  if (!before || !after) {
+    return false;
+  }
+  if (Object.keys(before).length !== Object.keys(after).length) {
+    return false;
+  }
+  if (before.children?.length !== after.children?.length) {
+    return false;
+  }
+  // Can't compare objects directly because they are in different memory locations
+  // But we can compare strings
+  if (JSON.stringify(before) !== JSON.stringify(after)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * This selector factory provides an alternative means for a widget to get its
+ * position props. Generally the <Widget> wrapper should manage position and the
+ * useContainerWidth hook should be used to get a measured width and height.
+ * But in some rare situations these props need be be known before first render
+ * and are not expected to change, for example through a react grid layout resize.
+ * @returns A new selector that gets the widget position properties
+ */
+export const makeSelectWidgetPosition = () =>
+  createSelector(
+    [selectFile, (_state: any, _fileId: string, widgetId: string) => widgetId],
+    (file, widgetId) =>
+      file
+        ? (findWidgetById([file], widgetId)?.position as Position | undefined)
+        : undefined
+  );

--- a/src/redux/slices/storeUtils.ts
+++ b/src/redux/slices/storeUtils.ts
@@ -1,0 +1,26 @@
+import { WidgetDescription } from "../../ui/widgets/createComponent";
+
+/**
+ * Find an item in a tree by it's id.
+ * @param tree The widget hierarchy
+ * @param id The id of the widget to find.
+ * @returns The matching widget description or undefined
+ */
+
+export const findWidgetById = (
+  tree: WidgetDescription[] | undefined,
+  id: string
+): WidgetDescription | undefined => {
+  if (!Array.isArray(tree)) return undefined;
+
+  for (const node of tree) {
+    if (!node || typeof node !== "object") continue;
+
+    if (node.id === id) return node;
+
+    const found = findWidgetById(node.children, id);
+    if (found) return found;
+  }
+
+  return undefined;
+};

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -7,6 +7,7 @@ import {
 import csReducer from "./csState";
 import notificationsReducer from "./slices/notificationsSlice";
 import configurationReducer from "./slices/configurationSlice";
+import fileCacheReducer from "./slices/fileCacheSlice";
 import { connectionMiddleware } from "./connectionMiddleware";
 import { throttleMiddleware, UpdateThrottle } from "./throttleMiddleware";
 import { CsWebLibConfig } from "./csWebLibConfig";
@@ -17,7 +18,8 @@ let storeInstance: ReturnType<typeof configureStore> | null = null;
 export const rootReducer = combineReducers({
   configuration: configurationReducer,
   cs: csReducer,
-  notifications: notificationsReducer
+  notifications: notificationsReducer,
+  fileCache: fileCacheReducer
 });
 
 const createStoreInstance = (config?: CsWebLibConfig) => {

--- a/src/testResources.tsx
+++ b/src/testResources.tsx
@@ -19,6 +19,7 @@ import {
   initialNotificationsState,
   NotificationStack
 } from "./redux/slices/notificationsSlice";
+import { FileCache, FileCacheState } from "./redux/slices/fileCacheSlice";
 
 // Helper functions for dtypes.
 export function ddouble(
@@ -77,10 +78,12 @@ export const ACTIONS_EX_FIRST = {
 
 export const createRootStoreState = (
   csState?: CsState,
-  notifications?: NotificationStack
+  notifications?: NotificationStack,
+  fileCache?: FileCacheState
 ) => ({
   cs: csState ?? initialCsState,
-  notifications: notifications ?? initialNotificationsState
+  notifications: notifications ?? initialNotificationsState,
+  fileCache: fileCache ?? ({} as FileCache)
 });
 
 export const contextWrapperGenerator = (
@@ -107,7 +110,8 @@ export const contextWrapperGenerator = (
     reducer: rootReducer,
     preloadedState: {
       ...initialRootStoreState,
-      cs: { ...initialRootStoreState.cs, globalMacros: extendedGlobalMacros }
+      cs: { ...initialRootStoreState.cs, globalMacros: extendedGlobalMacros },
+      fileCache: { fileCache: {} }
     }
   });
 

--- a/src/ui/hooks/useConnection.test.tsx
+++ b/src/ui/hooks/useConnection.test.tsx
@@ -39,7 +39,6 @@ function getConnectionState(pvName: string, value: DType): CsState {
     globalMacros: {},
     effectivePvNameMap: {},
     deviceCache: {},
-    fileCache: {},
     pvwsSettings: {}
   };
 }

--- a/src/ui/hooks/useDevice.test.tsx
+++ b/src/ui/hooks/useDevice.test.tsx
@@ -16,7 +16,6 @@ function getConnectionState(): CsState {
     globalMacros: {},
     effectivePvNameMap: {},
     deviceCache: { testDevice: newDType({ stringValue: "42" }) },
-    fileCache: {},
     pvwsSettings: {}
   };
 }

--- a/src/ui/hooks/useFile.test.tsx
+++ b/src/ui/hooks/useFile.test.tsx
@@ -34,7 +34,6 @@ function getFileState(): CsState {
     globalMacros: {},
     effectivePvNameMap: {},
     deviceCache: {},
-    fileCache: {},
     pvwsSettings: {}
   };
 }

--- a/src/ui/hooks/useFile.test.tsx
+++ b/src/ui/hooks/useFile.test.tsx
@@ -104,7 +104,8 @@ describe("useFile", (): void => {
       children: [],
       precisionFromPv: true,
       showUnits: true,
-      wrapWords: true
+      wrapWords: true,
+      fileId: "test.json"
     });
     expect(
       screen.getByText(`contents: ${responseContent}`)

--- a/src/ui/hooks/useFile.test.tsx
+++ b/src/ui/hooks/useFile.test.tsx
@@ -54,6 +54,7 @@ describe("useFile", (): void => {
     const responseContent = JSON.stringify({
       type: "shape",
       id: "123",
+      fileId: "AShapeFilePath",
       position: newAbsolutePosition("0", "0", "0", "0")
     });
 

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -4,7 +4,7 @@ import {
   refreshFile as refreshFileAction,
   selectFile,
   fileComparator
-} from "../../redux/csState";
+} from "../../redux/slices/fileCacheSlice";
 import { MacroMap } from "../../types/macros";
 import { errorWidget, WidgetDescription } from "../widgets/createComponent";
 import { useEffect } from "react";

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -49,13 +49,24 @@ async function fetchAndConvert(
       // Convert the contents to widget description style object
       switch (fileExt) {
         case "bob":
-          description = await parseBob(contents, protocol, parentDir, macros);
+          description = await parseBob(
+            contents,
+            protocol,
+            parentDir,
+            macros,
+            filepath
+          );
           break;
         case "json":
-          description = await parseJson(contents, protocol, parentDir);
+          description = await parseJson(
+            contents,
+            protocol,
+            parentDir,
+            filepath
+          );
           break;
         case "opi":
-          description = await parseOpi(contents, protocol, parentDir);
+          description = await parseOpi(contents, protocol, parentDir, filepath);
           break;
       }
     }

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -19,6 +19,7 @@ import { newAbsolutePosition } from "../../types/position";
 const EMPTY_WIDGET: WidgetDescription = {
   type: "shape",
   id: "123",
+  fileId: "AShapeFilePath",
   position: newAbsolutePosition("0", "0", "0", "0")
 };
 

--- a/src/ui/hooks/useMacros.test.tsx
+++ b/src/ui/hooks/useMacros.test.tsx
@@ -37,7 +37,6 @@ const buildInitialCsState = (): CsState => ({
   subscriptions: {},
   valueCache: {},
   deviceCache: {},
-  fileCache: {},
   pvwsSettings: {}
 });
 

--- a/src/ui/hooks/useRules.test.tsx
+++ b/src/ui/hooks/useRules.test.tsx
@@ -38,7 +38,6 @@ function getCsState(value: DType): CsState {
     globalMacros: {},
     effectivePvNameMap: {},
     deviceCache: {},
-    fileCache: {},
     pvwsSettings: {}
   };
 }

--- a/src/ui/widgets/Device/device.test.tsx
+++ b/src/ui/widgets/Device/device.test.tsx
@@ -23,7 +23,7 @@ const descriptionToComponentMock = vi
 
 describe("<DeviceComponent />", (): void => {
   test("adds dev:// to deviceName", (): void => {
-    render(<DeviceComponent deviceName={"fake Device"} />);
+    render(<DeviceComponent id={"deviceId1"} deviceName={"fake Device"} />);
     expect(useDeviceMock).toHaveBeenCalledWith("dev://fakeDevice");
     expect(descriptionToComponentMock).toHaveBeenCalled();
   });

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -26,7 +26,9 @@ const DeviceProps = {
 };
 
 export const DeviceComponent = (
-  props: InferWidgetProps<typeof DeviceProps>
+  props: InferWidgetProps<typeof DeviceProps> & {
+    id?: string;
+  }
 ): JSX.Element => {
   // When replacing a detail panel, you can deduce device name
   // from the macro DESC on the screen.
@@ -47,9 +49,17 @@ export const DeviceComponent = (
         if (description && description.value) {
           jsonResponse = JSON.parse(description?.value?.stringValue || "");
           setBorder(borderNONE);
-          const jsonObject = parseResponse(jsonResponse as any);
+          const jsonObject = parseResponse(
+            jsonResponse as any,
+            replacedDeviceName
+          );
 
-          componentDescription = await parseObject(jsonObject, "ca");
+          componentDescription = await parseObject(
+            jsonObject,
+            "ca",
+            undefined,
+            replacedDeviceName
+          );
         } else {
           componentDescription = errorWidget(
             `No device ${replacedDeviceName} found.`,
@@ -63,7 +73,8 @@ export const DeviceComponent = (
       }
       setComponent(
         widgetDescriptionToComponent({
-          id: "123",
+          id: props?.id ?? `device_${crypto.randomUUID()}`,
+          fileId: replacedDeviceName,
           position: newRelativePosition("100%", "100%"),
           type: "display",
           children: [componentDescription]
@@ -71,7 +82,7 @@ export const DeviceComponent = (
       );
     };
     loadComponent();
-  }, [description, deviceName, replacedDeviceName]);
+  }, [description, deviceName, replacedDeviceName, props.id]);
 
   const style = useStyle({ border }, widgetName);
   return (

--- a/src/ui/widgets/Device/deviceParser.test.ts
+++ b/src/ui/widgets/Device/deviceParser.test.ts
@@ -39,13 +39,13 @@ describe("wordSplitter", (): void => {
 
 describe("createLabel", (): void => {
   test("Value is placed into label", (): void => {
-    expect(createLabel("ValueHere").text).toBe("Value Here");
+    expect(createLabel("ValueHere", "aFileId").text).toBe("Value Here");
   });
 });
 
 describe("createReadback", (): void => {
   test("pv is placed into readback", (): void => {
-    expect(createReadback("PvName").pvName).toBe("PvName");
+    expect(createReadback("PvName", "aFileId").pvName).toBe("PvName");
   });
 });
 
@@ -131,14 +131,14 @@ describe("parseResponseIntoObject", (): void => {
 
 describe("parseResponse", (): void => {
   test("empty response gives empty groupbox", (): void => {
-    const component = parseResponse({} as Response);
+    const component = parseResponse({} as Response, "aFileId");
     expect(component.type).toBe("groupbox");
     expect(component.name).toBe("Device");
     expect(component.children[0].children.length).toBe(0);
   });
 
   test("response is parsed", (): void => {
-    const component = parseResponse(fakeResponseJson);
+    const component = parseResponse(fakeResponseJson, "aFileId");
     expect(component.name).toMatch("M1 Yaw");
 
     const children = component.children[0].children;

--- a/src/ui/widgets/Device/deviceParser.ts
+++ b/src/ui/widgets/Device/deviceParser.ts
@@ -49,9 +49,10 @@ export interface Response {
 export const wordSplitter = (word: string): string =>
   word.replace(/([A-Z])/g, " $1").trim();
 
-export function createLabel(value: string): WidgetDescription {
+export function createLabel(value: string, fileId: string): WidgetDescription {
   return {
-    id: "123",
+    id: `label_${crypto.randomUUID()}`,
+    fileId,
     type: "label",
     position: "relative",
     text: `${wordSplitter(value)}`,
@@ -61,9 +62,10 @@ export function createLabel(value: string): WidgetDescription {
   };
 }
 
-export function createReadback(pv: string): WidgetDescription {
+export function createReadback(pv: string, fileId: string): WidgetDescription {
   return {
-    id: "123",
+    id: `readback_${crypto.randomUUID()}`,
+    fileId,
     type: "readback",
     position: "relative",
     width: "45%",
@@ -72,9 +74,10 @@ export function createReadback(pv: string): WidgetDescription {
   };
 }
 
-export function createInput(pv: string): WidgetDescription {
+export function createInput(pv: string, fileId: string): WidgetDescription {
   return {
-    id: "123",
+    id: `input_${crypto.randomUUID()}`,
+    fileId,
     type: "input",
     position: "relative",
     width: "45%",
@@ -85,10 +88,12 @@ export function createInput(pv: string): WidgetDescription {
 
 export function createButton(
   pv: string,
+  fileId: string,
   description?: string
 ): WidgetDescription {
   return {
-    id: "123",
+    id: `actionbutton_${crypto.randomUUID()}`,
+    fileId,
     type: "actionbutton",
     position: "relative",
     width: "45%",
@@ -112,7 +117,11 @@ export function createButton(
 }
 
 const WIDGET_FUNCTIONS: {
-  [name: string]: (pv: string, description?: string) => WidgetDescription;
+  [name: string]: (
+    pv: string,
+    fileId: string,
+    description?: string
+  ) => WidgetDescription;
 } = {
   TEXTUPDATE: createReadback,
   TEXTINPUT: createInput,
@@ -156,15 +165,15 @@ export const parseResponseIntoObject = (
   return [deviceName, pvIds, groups];
 };
 
-function createWidget(label: string, channel: Channel): any {
+function createWidget(label: string, channel: Channel, fileId: string): any {
   if (WIDGET_FUNCTIONS.hasOwnProperty(channel.display.widget)) {
-    return WIDGET_FUNCTIONS[channel.display.widget](channel.id, label);
+    return WIDGET_FUNCTIONS[channel.display.widget](channel.id, fileId, label);
   } else {
-    return createReadback(channel.id);
+    return createReadback(channel.id, fileId);
   }
 }
 
-export const parseResponse = (response: Response): any => {
+export const parseResponse = (response: Response, fileId: string): any => {
   const deviceChildren: any[] = [];
 
   let deviceName = "Device";
@@ -182,8 +191,8 @@ export const parseResponse = (response: Response): any => {
       for (const pvName of pvNames) {
         const channel = channels[pvName];
         delete channels[pvName];
-        groupChildren.push(createLabel(pvName));
-        groupChildren.push(createWidget(pvName, channel));
+        groupChildren.push(createLabel(pvName, fileId));
+        groupChildren.push(createWidget(pvName, channel, fileId));
       }
 
       return {
@@ -206,8 +215,8 @@ export const parseResponse = (response: Response): any => {
     // PVs that aren't in a group are displayed first
     Object.entries(channels).forEach(data => {
       const [label, channel] = data;
-      deviceChildren.push(createLabel(label));
-      deviceChildren.push(createWidget(label, channel));
+      deviceChildren.push(createLabel(label, fileId));
+      deviceChildren.push(createWidget(label, channel, fileId));
     });
 
     // Then groups are displayed after

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
@@ -254,7 +254,7 @@ describe("DisplayGridLayoutComponent", () => {
     expect(mocks.calculateDefaultLayout).toHaveBeenCalledWith(
       expect.any(Array),
       1200,
-      32,
+      17,
       [6, 6],
       15
     );

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
@@ -17,7 +17,7 @@ vi.mock("react-grid-layout", async () => {
 
   return {
     ...actual,
-
+    useGridLayout,
     ReactGridLayout: (props: any) => {
       lastProps = props;
       return <div data-testid="grid">{props.children}</div>;
@@ -29,13 +29,25 @@ vi.mock("react-grid-layout", async () => {
       containerRef: { current: null }
     }),
 
-    useGridLayout,
-
     verticalCompactor: vi.fn(),
 
-    __getLastGridProps: () => lastProps
+    __getLastGridProps: () => lastProps,
+
+    __resetGridProps: () => {
+      lastProps = null;
+    }
   };
 });
+
+vi.mock("react-redux", () => ({
+  useDispatch: () => vi.fn(),
+  useSelector: (selector: any) =>
+    selector({
+      csState: {
+        files: {}
+      }
+    })
+}));
 
 vi.mock("../../hooks/useStyle", () => ({
   useStyle: () => ({
@@ -45,6 +57,28 @@ vi.mock("../../hooks/useStyle", () => ({
     other: {}
   })
 }));
+
+const mocks = vi.hoisted(() => ({
+  calculateDefaultLayout: vi.fn()
+}));
+
+vi.mock("./displayLayoutUtilities", () => ({
+  calculateDefaultLayout: mocks.calculateDefaultLayout,
+  toNumber: (v: any, fallback: number) => Number(v ?? fallback)
+}));
+
+vi.mock("../../../redux/csState", async () => {
+  const actual = await vi.importActual("../../../redux/csState");
+  return {
+    ...actual,
+    makeSelectWidgetPosition: () => {
+      return (_state: any, _fileId: string, _id: string) => ({
+        width: 1200
+      });
+    },
+    fileDisplaySetRGLayout: vi.fn()
+  };
+});
 
 vi.mock("../../hooks/useDebounce", () => ({
   useDebouncedValue: (v: any) => v
@@ -73,33 +107,49 @@ const renderGrid = (props: any = {}) =>
   );
 
 describe("DisplayGridLayoutComponent", () => {
-  it("renders the grid and children", () => {
-    renderGrid();
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const rgl = (await import("react-grid-layout")) as any;
+    rgl.__resetGridProps();
+  });
 
+  it("renders the grid and children", () => {
+    renderGrid({ gridLayout: [{ i: "a", w: 8, h: 4 }] });
+
+    expect(mocks.calculateDefaultLayout).not.toHaveBeenCalled();
     expect(screen.getByTestId("grid")).toBeInTheDocument();
     expect(screen.getByTestId("child-a")).toBeInTheDocument();
     expect(screen.getByTestId("child-b")).toBeInTheDocument();
   });
 
   it("sets cursor to grab when gridCellDragEnabled=true (default)", () => {
-    renderGrid();
+    renderGrid({ gridLayout: [{ i: "a", w: 8, h: 4 }] });
 
     const wrapper = screen.getByTestId("child-a").parentElement;
     expect(wrapper?.style.cursor).toBe("grab");
   });
 
   it("sets cursor to default when gridCellDragEnabled=false", () => {
-    renderGrid({ gridCellDragEnabled: false });
+    renderGrid({
+      gridCellDragEnabled: false,
+      gridLayout: [{ i: "a", w: 8, h: 4 }]
+    });
 
     const wrapper = screen.getByTestId("child-a").parentElement;
     expect(wrapper?.style.cursor).toBe("default");
   });
 
-  it("passes correct config into useGridLayout", async () => {
+  it("passes correct cols into useGridLayout", async () => {
     const { useGridLayout } = await import("react-grid-layout");
     const spy = vi.spyOn({ useGridLayout }, "useGridLayout");
 
-    renderGrid({ gridLayoutColumns: 16 });
+    renderGrid({
+      gridLayoutColumns: 16,
+      gridLayout: [
+        { i: "a", w: 8, h: 4 },
+        { i: "b", w: 8, h: 4 }
+      ]
+    });
 
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -112,10 +162,15 @@ describe("DisplayGridLayoutComponent", () => {
     );
   });
 
-  it("generates default layout when gridLayout is not provided", async () => {
+  it("generates layout when gridLayout is provided", async () => {
     const { useGridLayout } = await import("react-grid-layout");
 
-    renderGrid();
+    renderGrid({
+      gridLayout: [
+        { i: "a", w: 8, h: 4 },
+        { i: "b", w: 8, h: 4 }
+      ]
+    });
 
     expect(useGridLayout).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -129,7 +184,9 @@ describe("DisplayGridLayoutComponent", () => {
 
   it("updates cursor during drag lifecycle when enabled", async () => {
     const rgl = (await import("react-grid-layout")) as any;
-    renderGrid();
+    renderGrid({
+      gridLayout: [{ i: "widget-1", x: 0, y: 0, w: 2, h: 2 }]
+    });
 
     const gridProps = rgl.__getLastGridProps();
     const el = document.createElement("div");
@@ -143,7 +200,10 @@ describe("DisplayGridLayoutComponent", () => {
 
   it("does not change cursor during drag lifecycle when drag disabled", async () => {
     const rgl = (await import("react-grid-layout")) as any;
-    renderGrid({ gridCellDragEnabled: false });
+    renderGrid({
+      gridCellDragEnabled: false,
+      gridLayout: [{ i: "widget-1", x: 0, y: 0, w: 2, h: 2 }]
+    });
 
     const gridProps = rgl.__getLastGridProps();
     const el = document.createElement("div");
@@ -173,37 +233,73 @@ describe("DisplayGridLayoutComponent", () => {
   it("toggles resizeConfig.enabled based on gridCellResizeEnabled", async () => {
     const rgl = (await import("react-grid-layout")) as any;
 
-    renderGrid({ gridCellResizeEnabled: false });
+    renderGrid({
+      gridCellResizeEnabled: false,
+      gridLayout: [{ i: "widget-1", x: 0, y: 0, w: 2, h: 2 }]
+    });
 
     expect(rgl.__getLastGridProps().resizeConfig.enabled).toBe(false);
 
-    renderGrid({ gridCellResizeEnabled: true });
+    renderGrid({
+      gridCellResizeEnabled: true,
+      gridLayout: [{ i: "widget-1", x: 0, y: 0, w: 2, h: 2 }]
+    });
 
     expect(rgl.__getLastGridProps().resizeConfig.enabled).toBe(true);
   });
 
-  it("uses default and overridden gridConfig values", async () => {
+  it("Calls calculateDefaultLayout with default values, when layout is undefined", async () => {
+    renderGrid();
+
+    expect(mocks.calculateDefaultLayout).toHaveBeenCalledWith(
+      expect.any(Array),
+      1200,
+      32,
+      [6, 6],
+      15
+    );
+  });
+
+  it("Calls calculateDefaultLayout with props values, when layout is undefined", async () => {
+    renderGrid({
+      gridCellDragEnabled: false,
+      gridCellResizeEnabled: false,
+      gridCellHeight: 30,
+      gridCellMargins: [3, 3],
+      gridLayoutColumns: 50
+    });
+
+    expect(mocks.calculateDefaultLayout).toHaveBeenCalledWith(
+      expect.any(Array),
+      1200,
+      50,
+      [3, 3],
+      30
+    );
+  });
+
+  it("Does not render if gridLayout is empty and overridden gridConfig values", async () => {
     const rgl = (await import("react-grid-layout")) as any;
 
     // defaults
-    renderGrid();
-    let config = rgl.__getLastGridProps().gridConfig;
+    renderGrid({ gridLayout: [] });
+    let config = rgl.__getLastGridProps()?.gridConfig;
 
-    expect(config.cols).toBe(32);
-    expect(config.margin).toEqual([6, 6]);
-    expect(config.rowHeight).toBe(15);
+    expect(config).toBeUndefined();
 
     // overrides
     renderGrid({
       gridLayoutColumns: 20,
       gridCellMargins: [10, 12],
-      gridCellHeight: 25
+      gridCellHeight: 25,
+      gridLayout: [{ i: "widget-1", x: 0, y: 0, w: 2, h: 2 }]
     });
 
-    config = rgl.__getLastGridProps().gridConfig;
+    config = rgl.__getLastGridProps()?.gridConfig;
 
-    expect(config.cols).toBe(20);
-    expect(config.margin).toEqual([10, 12]);
-    expect(config.rowHeight).toBe(25);
+    expect(config).not.toBeUndefined();
+    expect(config?.cols).toBe(20);
+    expect(config?.margin).toEqual([10, 12]);
+    expect(config?.rowHeight).toBe(25);
   });
 });

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.test.tsx
@@ -45,6 +45,9 @@ vi.mock("react-redux", () => ({
     selector({
       csState: {
         files: {}
+      },
+      fileCache: {
+        fileCache: {}
       }
     })
 }));

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -42,7 +42,7 @@ import { calculateDefaultLayout, toNumber } from "./displayLayoutUtilities";
 import {
   fileDisplaySetGridLayout,
   makeSelectWidgetPosition
-} from "../../../redux/csState";
+} from "../../../redux/slices/fileCacheSlice";
 import { useDispatch, useSelector } from "react-redux";
 
 const widgetName = "displayGridLayout";

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -48,8 +48,8 @@ import { useDispatch, useSelector } from "react-redux";
 const widgetName = "displayGridLayout";
 
 // Default grid configuration
-const defaultCols = 32;
 const defaultRowHeight = 15;
+const defaultColumnWidth = 64;
 const defaultMargins = [6, 6];
 
 const DisplayGridLayoutProps = {
@@ -144,8 +144,8 @@ export const DisplayGridLayoutComponent = (
   );
 
   const columns = React.useMemo(
-    () => props.gridLayoutColumns ?? defaultCols,
-    [props.gridLayoutColumns]
+    () => props.gridLayoutColumns ?? Math.round((displayWidth - cellMargins[0]) / (defaultColumnWidth + cellMargins[0])),
+    [props.gridLayoutColumns, cellMargins, displayWidth]
   );
 
   useEffect(() => {

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -1,7 +1,12 @@
-import React, { useState, useContext, ReactNode } from "react";
+import React, {
+  useState,
+  useContext,
+  ReactNode,
+  useMemo,
+  useEffect
+} from "react";
 import {
   Layout,
-  useContainerWidth,
   useGridLayout,
   ReactGridLayout,
   verticalCompactor
@@ -24,7 +29,8 @@ import {
   StringArrayPropOpt,
   IntPropOpt,
   ObjectArrayPropOpt,
-  IntArrayPropOpt
+  IntArrayPropOpt,
+  PositionProp
 } from "../propTypes";
 import {
   MacroMap,
@@ -32,7 +38,12 @@ import {
   MacroContextType
 } from "../../../types/macros";
 import { useStyle } from "../../hooks/useStyle";
-import { useDebouncedValue } from "../../hooks/useDebounce";
+import { calculateDefaultLayout, toNumber } from "./displayLayoutUtilities";
+import {
+  fileDisplaySetRGLayout,
+  makeSelectWidgetPosition
+} from "../../../redux/csState";
+import { useDispatch, useSelector } from "react-redux";
 
 const widgetName = "displayGridLayout";
 
@@ -42,6 +53,7 @@ const defaultRowHeight = 15;
 const defaultMargins = [6, 6];
 
 const DisplayGridLayoutProps = {
+  position: PositionProp,
   children: ChildrenPropOpt,
   overflow: ChoicePropOpt(["scroll", "hidden", "auto", "visible"]),
   backgroundColor: ColorPropOpt,
@@ -61,15 +73,15 @@ const DisplayGridLayoutProps = {
 
 // Display widget that uses react-grid-layout to provide a responsive drag and drop container
 export const DisplayGridLayoutComponent = (
-  props: InferWidgetProps<typeof DisplayGridLayoutProps> & { id: string }
+  props: InferWidgetProps<typeof DisplayGridLayoutProps> & {
+    id: string;
+    fileId: string;
+  }
 ): JSX.Element => {
   // Macros specific to this display. Children of this component
   // can set macros by using the updateMacro function on the
   // context.
-  const { width, containerRef, mounted } = useContainerWidth({
-    measureBeforeMount: false
-  });
-  const debouncedWidth = useDebouncedValue(width, 150);
+  const dispatch = useDispatch();
   const gridCellDragEnabled =
     props?.gridCellDragEnabled == null ? true : props?.gridCellDragEnabled;
   const gridCellResizeEnabled =
@@ -80,6 +92,12 @@ export const DisplayGridLayoutComponent = (
     props.macros ?? {}
   );
 
+  const selectWidgetPosition = useMemo(makeSelectWidgetPosition, []);
+  const position = useSelector(state =>
+    selectWidgetPosition(state, props.fileId, props.id)
+  );
+  const displayWidth = toNumber(position?.width, 1200);
+  const cellHeight = Number(props.gridCellHeight ?? defaultRowHeight);
   const cellMargins = (props.gridCellMargins ?? defaultMargins) as [
     number,
     number
@@ -111,7 +129,8 @@ export const DisplayGridLayoutComponent = (
       ...style.font,
       position: "relative",
       overflow: props.overflow,
-      height: "100%"
+      height: "100%",
+      width: "100%"
     }),
     [style, props.overflow]
   );
@@ -129,18 +148,53 @@ export const DisplayGridLayoutComponent = (
     [props.gridLayoutColumns]
   );
 
-  const initialLayout = React.useMemo(
-    () => (props.gridLayout ?? calculateDefaultLayout(childrenArray)) as Layout,
-    [props.gridLayout, childrenArray]
-  );
+  useEffect(() => {
+    if (props.gridLayout) {
+      return;
+    }
+
+    // If a gridLayout does not exist create one and update the redux state for this
+    // display grid.
+    const calculatedLayout = calculateDefaultLayout(
+      childrenArray,
+      displayWidth,
+      columns,
+      cellMargins,
+      cellHeight
+    );
+    dispatch(
+      fileDisplaySetRGLayout({
+        file: props.fileId,
+        displayId: props.id,
+        gridLayout: calculatedLayout,
+        gridLayoutColumns: columns,
+        gridCellMargins: cellMargins,
+        gridCellHeight: cellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      })
+    );
+  }, [
+    dispatch,
+    props.fileId,
+    props.id,
+    props.gridLayout,
+    childrenArray,
+    columns,
+    displayWidth,
+    cellMargins,
+    cellHeight,
+    gridCellDragEnabled,
+    gridCellResizeEnabled
+  ]);
 
   const { layout } = useGridLayout({
-    layout: initialLayout,
+    layout: (props.gridLayout || []) as Layout,
     cols: columns
   });
 
   // Wrap the child components in a div keyed by the child id. The key MUST map to the i field of Layout item for the component.
-  const gridChildren = React.useMemo(
+  const gridChildren = useMemo(
     () =>
       childrenArray.map(child => {
         const id = child.props.id;
@@ -162,21 +216,17 @@ export const DisplayGridLayoutComponent = (
 
   return (
     <MacroContext.Provider value={displayMacroContext}>
-      <div
-        ref={containerRef as React.RefObject<HTMLDivElement>}
-        style={extendedStyle}
-        className="display-grid-layout-container"
-      >
-        {mounted && (
+      <div style={extendedStyle} className="display-grid-layout-container">
+        {layout && layout.length > 0 && (
           <ReactGridLayout
             key={`grid-${props.id}`}
             className="layout"
             layout={layout}
-            width={debouncedWidth}
+            width={displayWidth}
             gridConfig={{
               cols: columns,
               margin: cellMargins,
-              rowHeight: Number(props.gridCellHeight ?? defaultRowHeight)
+              rowHeight: cellHeight
             }}
             dragConfig={{
               enabled: gridCellDragEnabled,
@@ -217,17 +267,6 @@ const DisplayGridLayoutWidgetProps = {
   ...DisplayGridLayoutProps,
   ...WidgetPropType
 };
-
-const calculateDefaultLayout = (
-  childrenArray: React.ReactElement<PVWidgetComponent>[]
-): Layout =>
-  childrenArray.map((child, i) => ({
-    i: child.props.id,
-    x: (i % 4) * 8,
-    y: Math.floor(i / 4),
-    w: 8,
-    h: 4
-  })) as Layout;
 
 export const DisplayGridLayout = (
   props: InferWidgetProps<typeof DisplayGridLayoutWidgetProps>

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -40,7 +40,7 @@ import {
 import { useStyle } from "../../hooks/useStyle";
 import { calculateDefaultLayout, toNumber } from "./displayLayoutUtilities";
 import {
-  fileDisplaySetRGLayout,
+  fileDisplaySetGridLayout,
   makeSelectWidgetPosition
 } from "../../../redux/csState";
 import { useDispatch, useSelector } from "react-redux";
@@ -144,7 +144,11 @@ export const DisplayGridLayoutComponent = (
   );
 
   const columns = React.useMemo(
-    () => props.gridLayoutColumns ?? Math.round((displayWidth - cellMargins[0]) / (defaultColumnWidth + cellMargins[0])),
+    () =>
+      props.gridLayoutColumns ??
+      Math.round(
+        (displayWidth - cellMargins[0]) / (defaultColumnWidth + cellMargins[0])
+      ),
     [props.gridLayoutColumns, cellMargins, displayWidth]
   );
 
@@ -163,7 +167,7 @@ export const DisplayGridLayoutComponent = (
       cellHeight
     );
     dispatch(
-      fileDisplaySetRGLayout({
+      fileDisplaySetGridLayout({
         file: props.fileId,
         displayId: props.id,
         gridLayout: calculatedLayout,

--- a/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.test.ts
+++ b/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  calculateDefaultLayout,
+  calculateDefaultLayoutWithHorizontalCompactor,
+  toNumber,
+  sameKeys
+} from "./displayLayoutUtilities";
+import { horizontalCompactor, verticalCompactor } from "react-grid-layout";
+
+vi.mock("react-grid-layout", () => ({
+  horizontalCompactor: {
+    compact: vi.fn(layout => layout)
+  },
+  verticalCompactor: {
+    compact: vi.fn(layout => layout)
+  }
+}));
+
+const createChild = (id: string, position = {}) =>
+  ({
+    props: { id, position }
+  }) as any;
+
+describe("toNumber", () => {
+  it("returns valid numbers as-is", () => {
+    expect(toNumber(10)).toBe(10);
+  });
+
+  it("returns fallback for invalid numbers", () => {
+    expect(toNumber(NaN, 5)).toBe(5);
+    expect(toNumber(Infinity, 5)).toBe(5);
+  });
+
+  it("parses numeric strings", () => {
+    expect(toNumber("42")).toBe(42);
+    expect(toNumber("42.5")).toBe(42.5);
+  });
+
+  it("returns fallback for percentage strings", () => {
+    expect(toNumber("50%", 3)).toBe(3);
+  });
+
+  it("returns fallback for invalid strings", () => {
+    expect(toNumber("abc", 7)).toBe(7);
+  });
+
+  it("returns fallback for null/undefined", () => {
+    expect(toNumber(undefined, 2)).toBe(2);
+    expect(toNumber(null, 2)).toBe(2);
+  });
+});
+
+describe("sameKeys", () => {
+  it("returns true for identical keys (order independent)", () => {
+    expect(sameKeys({ a: 1, b: 2 }, { b: 3, a: 4 })).toBe(true);
+  });
+
+  it("returns false when keys differ", () => {
+    expect(sameKeys({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it("returns false for completely different keys", () => {
+    expect(sameKeys({ a: 1 }, { b: 2 })).toBe(false);
+  });
+
+  it("returns true for empty objects", () => {
+    expect(sameKeys({}, {})).toBe(true);
+  });
+});
+
+describe("calculateDefaultLayout", () => {
+  const margins: [number, number] = [6, 6];
+  const cellHeight = 15;
+
+  it("creates layout entries for each child", () => {
+    const children = [createChild("a"), createChild("b")];
+
+    const layout = calculateDefaultLayout(
+      children,
+      1200,
+      12,
+      margins,
+      cellHeight
+    );
+
+    expect(layout).toHaveLength(2);
+    expect(layout[0]).toMatchObject({ i: "a" });
+    expect(layout[1]).toMatchObject({ i: "b" });
+  });
+
+  it("uses default values when no position is provided", () => {
+    const children = [createChild("a")];
+
+    const layout = calculateDefaultLayout(
+      children,
+      1200,
+      12,
+      margins,
+      cellHeight
+    );
+
+    expect(layout[0]).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 1,
+      h: 1
+    });
+  });
+
+  it("calculates width and height based on position", () => {
+    const children = [createChild("a", { width: 200, height: 60 })];
+
+    const layout = calculateDefaultLayout(
+      children,
+      1200,
+      12,
+      margins,
+      cellHeight
+    );
+
+    expect(layout[0].w).toBe(3);
+    expect(layout[0].h).toBe(3);
+  });
+
+  it("calculates x and y positions", () => {
+    const children = [createChild("a", { x: 100, y: 50 })];
+
+    const layout = calculateDefaultLayout(
+      children,
+      1200,
+      12,
+      margins,
+      cellHeight
+    );
+
+    expect(layout[0].x).toBe(1);
+    expect(layout[0].y).toBe(2);
+  });
+
+  it("never produces negative coordinates", () => {
+    const children = [createChild("a", { x: -100, y: -50 })];
+
+    const layout = calculateDefaultLayout(
+      children,
+      1200,
+      12,
+      margins,
+      cellHeight
+    );
+
+    expect(layout[0].x).toBe(0);
+    expect(layout[0].y).toBe(0);
+  });
+
+  it("calls verticalCompactor", () => {
+    const children = [createChild("a")];
+
+    calculateDefaultLayout(children, 1200, 12, margins, cellHeight);
+
+    expect(verticalCompactor.compact).toHaveBeenCalled();
+  });
+});
+
+describe("calculateDefaultLayoutWithHorizontalCompactor", () => {
+  it("calls horizontalCompactor after generating layout", () => {
+    const children = [createChild("a")];
+
+    const layout = calculateDefaultLayoutWithHorizontalCompactor(
+      children,
+      1200,
+      12,
+      [6, 6],
+      15
+    );
+
+    expect(horizontalCompactor.compact).toHaveBeenCalledWith(
+      expect.any(Array),
+      12
+    );
+
+    expect(layout).toEqual(expect.any(Array));
+  });
+});

--- a/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
+++ b/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
@@ -20,14 +20,14 @@ export const calculateDefaultLayout = (
     const y = toNumber(position?.y, 0);
 
     const widthColumns = width
-      ? Math.max(1, Math.round(width / columnWidth))
+      ? Math.max(1, Math.ceil(width / columnWidth))
       : 1;
 
     const heightRows = height
       ? Math.max(1, Math.round(height / (cellHeight + cellMargins[1])))
       : 1;
 
-    const gridX = Math.max(0, Math.round(x / columnWidth));
+    const gridX = Math.max(0, Math.round(x / columnWidth)) % numberOfColumns;
     const gridY = Math.max(0, Math.round(y / (cellHeight + cellMargins[1])));
 
     return {

--- a/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
+++ b/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
@@ -1,17 +1,41 @@
-import { Layout } from "react-grid-layout";
+import {
+  Layout,
+  horizontalCompactor,
+  verticalCompactor
+} from "react-grid-layout";
 import { PVWidgetComponent } from "../widgetProps";
 
-export const calculateDefaultLayout = (
+export const calculateDefaultLayoutWithHorizontalCompactor = (
   childrenArray: React.ReactElement<PVWidgetComponent>[],
   displayWidth: number | string,
   numberOfColumns: number,
   cellMargins: [number, number],
   cellHeight: number
 ): Layout => {
+  const layout = calculateDefaultLayout(
+    childrenArray,
+    displayWidth,
+    numberOfColumns,
+    cellMargins,
+    cellHeight
+  );
+
+  // vertical compactor will fill empty area to the left of screen
+  return horizontalCompactor.compact(layout, numberOfColumns);
+};
+
+export const calculateDefaultLayout = (
+  childrenArray: React.ReactElement<PVWidgetComponent>[],
+  displayWidth: string | number,
+  numberOfColumns: number,
+  cellMargins: [number, number],
+  cellHeight: number
+) => {
   const columnWidth =
     (toNumber(displayWidth, 1200) - cellMargins[0]) / numberOfColumns;
 
-  return childrenArray.map((child, i) => {
+  //
+  const layout = childrenArray.map((child, i) => {
     const { id, position = {} as any } = child.props;
 
     const height = toNumber(position?.height, 1);
@@ -27,8 +51,11 @@ export const calculateDefaultLayout = (
       ? Math.max(1, Math.round(height / (cellHeight + cellMargins[1])))
       : 1;
 
-    const gridX = Math.max(0, Math.round(x / columnWidth)) % numberOfColumns;
-    const gridY = Math.max(0, Math.round(y / (cellHeight + cellMargins[1])));
+    let gridX = Math.max(0, Math.round(x / columnWidth)) % numberOfColumns;
+    if (gridX + widthColumns > columnWidth) {
+      gridX = 0;
+    }
+    const gridY = Math.max(0, Math.floor(y / (cellHeight + cellMargins[1])));
 
     return {
       i: id,
@@ -38,6 +65,9 @@ export const calculateDefaultLayout = (
       h: heightRows
     };
   }) as Layout;
+
+  // vertical compactor will position the elements in a column structure
+  return verticalCompactor.compact(layout, numberOfColumns);
 };
 
 export const toNumber = (value: unknown, fallback = 0): number => {

--- a/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
+++ b/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
@@ -84,3 +84,14 @@ export const toNumber = (value: unknown, fallback = 0): number => {
 
   return fallback;
 };
+
+export const sameKeys = (a: object, b: object) => {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  return (
+    keysA.length === keysB.length &&
+    new Set(keysA).size === new Set(keysB).size &&
+    [...new Set(keysA)].every(item => keysB.includes(item))
+  );
+};

--- a/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
+++ b/src/ui/widgets/DisplayReactGridLayout/displayLayoutUtilities.ts
@@ -1,0 +1,56 @@
+import { Layout } from "react-grid-layout";
+import { PVWidgetComponent } from "../widgetProps";
+
+export const calculateDefaultLayout = (
+  childrenArray: React.ReactElement<PVWidgetComponent>[],
+  displayWidth: number | string,
+  numberOfColumns: number,
+  cellMargins: [number, number],
+  cellHeight: number
+): Layout => {
+  const columnWidth =
+    (toNumber(displayWidth, 1200) - cellMargins[0]) / numberOfColumns;
+
+  return childrenArray.map((child, i) => {
+    const { id, position = {} as any } = child.props;
+
+    const height = toNumber(position?.height, 1);
+    const width = toNumber(position?.width, 1);
+    const x = toNumber(position?.x, 0);
+    const y = toNumber(position?.y, 0);
+
+    const widthColumns = width
+      ? Math.max(1, Math.round(width / columnWidth))
+      : 1;
+
+    const heightRows = height
+      ? Math.max(1, Math.round(height / (cellHeight + cellMargins[1])))
+      : 1;
+
+    const gridX = Math.max(0, Math.round(x / columnWidth));
+    const gridY = Math.max(0, Math.round(y / (cellHeight + cellMargins[1])));
+
+    return {
+      i: id,
+      x: gridX,
+      y: gridY,
+      w: widthColumns,
+      h: heightRows
+    };
+  }) as Layout;
+};
+
+export const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  if (typeof value === "string") {
+    if (value.endsWith("%")) return fallback;
+
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+};

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { DisplayResponsiveComponent } from "./displayResponsive";
+import { fileDisplaySetResponsiveLayout } from "../../../redux/csState";
+import { calculateDefaultLayoutWithHorizontalCompactor } from "./displayLayoutUtilities";
 
 let capturedLayouts: any;
 let capturedBreakpoints: any;
@@ -42,8 +44,13 @@ vi.mock("react-grid-layout", async () => {
   };
 });
 
+let dispatchMock: any;
+
 vi.mock("react-redux", () => ({
-  useDispatch: () => vi.fn(),
+  useDispatch: () => {
+    dispatchMock = vi.fn();
+    return dispatchMock;
+  },
   useSelector: (selector: any) =>
     selector({
       csState: {
@@ -51,6 +58,17 @@ vi.mock("react-redux", () => ({
       }
     })
 }));
+
+vi.mock("./displayLayoutUtilities", async () => {
+  const actual = await vi.importActual<any>("./displayLayoutUtilities");
+
+  return {
+    ...actual,
+    calculateDefaultLayoutWithHorizontalCompactor: vi.fn(() => [
+      { i: "mock", x: 0, y: 0, w: 1, h: 1 }
+    ])
+  };
+});
 
 const MockWidget = ({ id }: { id: string }) => (
   <div data-testid={`widget-${id}`}>Widget {id}</div>
@@ -62,6 +80,7 @@ beforeEach(() => {
   capturedCols = undefined;
   capturedDragEnabled = undefined;
   capturedResizeEnabled = undefined;
+  vi.clearAllMocks();
 });
 
 describe("DisplayResponsiveComponent – high‑value behaviors", () => {
@@ -223,5 +242,125 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
 
     expect(capturedDragEnabled).toBe(false);
     expect(capturedResizeEnabled).toBe(false);
+  });
+
+  it("dispatches fallback layouts when responsiveLayouts keys are inconsistent", () => {
+    render(
+      <DisplayResponsiveComponent
+        id="display-1"
+        fileId="file-1"
+        responsiveLayouts={{
+          md: [{ i: "a", x: 0, y: 0, w: 2, h: 2 }]
+        }}
+        responsiveBreakpoints={{ lg: 1200 }}
+      >
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    const dispatchedArg = dispatchMock.mock.calls[0][0];
+
+    expect(dispatchedArg).toEqual(
+      fileDisplaySetResponsiveLayout(
+        expect.objectContaining({
+          displayId: "display-1",
+          file: "file-1",
+          responsiveLayouts: {
+            lg: expect.any(Array)
+          }
+        })
+      )
+    );
+  });
+
+  it("dispatches fallback columns when responsiveColumns keys are inconsistent", () => {
+    render(
+      <DisplayResponsiveComponent
+        id="display-1"
+        fileId="file-1"
+        responsiveLayouts={{
+          lg: [{ i: "a", x: 0, y: 0, w: 2, h: 2 }]
+        }}
+        responsiveBreakpoints={{ lg: 1200 }}
+        responsiveColumns={{ md: 4 }}
+      >
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    const dispatchedArg = dispatchMock.mock.calls[0][0];
+
+    expect(dispatchedArg.payload.responsiveColumns.lg).toBeDefined();
+    expect(dispatchedArg.payload.responsiveColumns.md).toBeUndefined();
+  });
+
+  it("uses fallback layout generator when layouts not specified", () => {
+    render(
+      <DisplayResponsiveComponent id="display-1" fileId="file-1">
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    expect(calculateDefaultLayoutWithHorizontalCompactor).toHaveBeenCalledTimes(
+      5
+    );
+
+    [1200, 800, 600, 400, 250].forEach(cols => {
+      expect(
+        calculateDefaultLayoutWithHorizontalCompactor
+      ).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            props: expect.objectContaining({ id: "a" })
+          })
+        ]),
+        cols,
+        Math.round((cols - 6) / (44 + 6)),
+        [6, 6],
+        15
+      );
+    });
+
+    const dispatchedArg = dispatchMock.mock.calls[0][0];
+    expect(dispatchedArg.payload.responsiveLayouts.lg).toEqual([
+      { i: "mock", x: 0, y: 0, w: 1, h: 1 }
+    ]);
+  });
+
+  it("uses fallback layout generator when configs are inconsistent", () => {
+    render(
+      <DisplayResponsiveComponent
+        id="display-1"
+        fileId="file-1"
+        responsiveLayouts={{ md: [] }}
+        responsiveBreakpoints={{ lg: 1150 }}
+        gridCellMargins={[3, 7]}
+        gridCellHeight={24}
+      >
+        <MockWidget id="a" />
+      </DisplayResponsiveComponent>
+    );
+
+    const expectedCols = Math.round((1150 - 3) / (44 + 3));
+
+    expect(calculateDefaultLayoutWithHorizontalCompactor).toHaveBeenCalled();
+    expect(calculateDefaultLayoutWithHorizontalCompactor).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          props: expect.objectContaining({ id: "a" })
+        })
+      ]),
+      1150,
+      expectedCols,
+      [3, 7],
+      24
+    );
+
+    const dispatchedArg = dispatchMock.mock.calls[0][0];
+    expect(dispatchedArg.payload.responsiveLayouts.lg).toEqual([
+      { i: "mock", x: 0, y: 0, w: 1, h: 1 }
+    ]);
   });
 });

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
@@ -42,6 +42,16 @@ vi.mock("react-grid-layout", async () => {
   };
 });
 
+vi.mock("react-redux", () => ({
+  useDispatch: () => vi.fn(),
+  useSelector: (selector: any) =>
+    selector({
+      csState: {
+        files: {}
+      }
+    })
+}));
+
 const MockWidget = ({ id }: { id: string }) => (
   <div data-testid={`widget-${id}`}>Widget {id}</div>
 );
@@ -56,8 +66,24 @@ beforeEach(() => {
 
 describe("DisplayResponsiveComponent – high‑value behaviors", () => {
   it("renders the responsive container and grid when mounted", () => {
+    const layouts = {
+      lg: [
+        { i: "a", x: 0, y: 0, w: 4, h: 3 },
+        { i: "b", x: 2, y: 0, w: 8, h: 4 }
+      ]
+    };
+
+    const responsiveBreakpoints = {
+      lg: 12
+    };
+
     render(
-      <DisplayResponsiveComponent id="display-1">
+      <DisplayResponsiveComponent
+        id="display-1"
+        fileId="file-1"
+        responsiveBreakpoints={responsiveBreakpoints}
+        responsiveLayouts={layouts}
+      >
         <MockWidget id="a" />
       </DisplayResponsiveComponent>
     );
@@ -74,7 +100,7 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
 
     expect(() =>
       render(
-        <DisplayResponsiveComponent id="display-1">
+        <DisplayResponsiveComponent id="display-1" fileId="file-1">
           <BrokenWidget />
         </DisplayResponsiveComponent>
       )
@@ -82,8 +108,24 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
   });
 
   it("computes default layouts when responsiveLayouts are not provided", () => {
+    const layouts = {
+      lg: [
+        { i: "a", x: 0, y: 0, w: 4, h: 3 },
+        { i: "b", x: 2, y: 0, w: 8, h: 4 }
+      ]
+    };
+
+    const responsiveBreakpoints = {
+      lg: 12
+    };
+
     render(
-      <DisplayResponsiveComponent id="display-1">
+      <DisplayResponsiveComponent
+        id="display-1"
+        fileId="file-1"
+        responsiveBreakpoints={responsiveBreakpoints}
+        responsiveLayouts={layouts}
+      >
         <MockWidget id="a" />
         <MockWidget id="b" />
       </DisplayResponsiveComponent>
@@ -94,8 +136,8 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
 
     expect(capturedLayouts.lg[0]).toMatchObject({
       i: "a",
-      w: 8,
-      h: 4
+      w: 4,
+      h: 3
     });
 
     expect(capturedLayouts.lg[1]).toMatchObject({
@@ -113,6 +155,7 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
     render(
       <DisplayResponsiveComponent
         id="display-1"
+        fileId="file-1"
         responsiveLayouts={customLayouts}
       >
         <MockWidget id="a" />
@@ -133,27 +176,44 @@ describe("DisplayResponsiveComponent – high‑value behaviors", () => {
   });
 
   it("merges responsiveBreakpoints and responsiveColumns with defaults", () => {
+    const layouts = {
+      md: [{ i: "a", x: 0, y: 0, w: 4, h: 3 }]
+    };
+
     render(
       <DisplayResponsiveComponent
         id="display-1"
+        fileId="file-1"
+        responsiveLayouts={layouts}
         responsiveBreakpoints={{ md: 700 }}
-        responsiveColumns={{ sm: 4 }}
+        responsiveColumns={{ md: 4 }}
       >
         <MockWidget id="a" />
       </DisplayResponsiveComponent>
     );
 
-    expect(capturedBreakpoints.lg).toBeDefined();
+    expect(capturedBreakpoints.lg).not.toBeDefined();
     expect(capturedBreakpoints.md).toBe(700);
 
-    expect(capturedCols.lg).toBeDefined();
-    expect(capturedCols.sm).toBe(4);
+    expect(capturedCols.lg).not.toBeDefined();
+    expect(capturedCols.md).toBe(4);
   });
 
   it("respects gridCellDragEnabled and gridCellResizeEnabled props", () => {
+    const layouts = {
+      lg: [{ i: "a", x: 0, y: 0, w: 4, h: 3 }]
+    };
+
+    const responsiveBreakpoints = {
+      lg: 12
+    };
+
     render(
       <DisplayResponsiveComponent
         id="display-1"
+        fileId="file-1"
+        responsiveLayouts={layouts}
+        responsiveBreakpoints={responsiveBreakpoints}
         gridCellDragEnabled={false}
         gridCellResizeEnabled={false}
       >

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { DisplayResponsiveComponent } from "./displayResponsive";
-import { fileDisplaySetResponsiveLayout } from "../../../redux/csState";
+import { fileDisplaySetResponsiveLayout } from "../../../redux/slices/fileCacheSlice";
 import { calculateDefaultLayoutWithHorizontalCompactor } from "./displayLayoutUtilities";
 
 let capturedLayouts: any;

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useContext, ReactNode } from "react";
+import React, { useState, useContext, ReactNode, useEffect } from "react";
 import {
-  Layout,
   ResponsiveLayouts,
   Responsive,
   useContainerWidth,
@@ -36,12 +35,15 @@ import {
 } from "../../../types/macros";
 import { useStyle } from "../../hooks/useStyle";
 import { useDebouncedValue } from "../../hooks/useDebounce";
+import { useDispatch } from "react-redux";
+import { calculateDefaultLayoutWithHorizontalCompactor } from "./displayLayoutUtilities";
+import { fileDisplaySetResponsiveLayout } from "../../../redux/csState";
 
 const widgetName = "displayResponsive";
 
 // Default grid configuration
-const defaultBreakpoints = { lg: 1200, md: 600, sm: 300 }; // These are minimum widths in pixels
-const defaultCols = { lg: 32, md: 16, sm: 8 };
+const defaultBreakpoints = { lg: 1200, md: 800, sm: 600, xs: 400, xxs: 250 }; // These are minimum widths in pixels
+const defaultColumnWidth = 44;
 const defaultRowHeight = 15;
 const defaultMargins = [6, 6];
 
@@ -66,11 +68,15 @@ const DisplayResponsiveProps = {
 
 // Display widget that uses react-grid-layout to provide a responsive drag and drop container
 export const DisplayResponsiveComponent = (
-  props: InferWidgetProps<typeof DisplayResponsiveProps> & { id: string }
+  props: InferWidgetProps<typeof DisplayResponsiveProps> & {
+    id: string;
+    fileId: string;
+  }
 ): JSX.Element => {
   // Macros specific to this display. Children of this component
   // can set macros by using the updateMacro function on the
   // context.
+  const dispatch = useDispatch();
   const { width, containerRef, mounted } = useContainerWidth({
     measureBeforeMount: false
   });
@@ -84,6 +90,8 @@ export const DisplayResponsiveComponent = (
   const [displayMacros, setDisplayMacros] = useState<MacroMap>(
     props.macros ?? {}
   );
+
+  const cellHeight = Number(props.gridCellHeight ?? defaultRowHeight);
 
   const updateMacro = React.useCallback((key: string, value: string) => {
     setDisplayMacros(prev => ({ ...prev, [key]: value }));
@@ -111,7 +119,8 @@ export const DisplayResponsiveComponent = (
       ...style.font,
       position: "relative",
       overflow: props.overflow,
-      height: "100%"
+      height: "100%",
+      width: "100%"
     }),
     [style, props.overflow]
   );
@@ -132,26 +141,76 @@ export const DisplayResponsiveComponent = (
   const breakpoints = React.useMemo(
     () =>
       (props?.responsiveBreakpoints
-        ? { ...defaultBreakpoints, ...props.responsiveBreakpoints }
+        ? props.responsiveBreakpoints
         : defaultBreakpoints) as Breakpoints<string>,
     [props.responsiveBreakpoints]
   );
 
-  const columns = React.useMemo(
-    () =>
-      (props.responsiveColumns
-        ? { ...defaultCols, ...props.responsiveColumns }
-        : defaultCols) as Breakpoints<DefaultBreakpoints>,
-    [props.responsiveColumns]
-  );
+  const columns = React.useMemo(() => {
+    if (props.responsiveColumns) {
+      return props.responsiveColumns as Breakpoints<Breakpoint>;
+    }
+
+    return Object.keys(breakpoints).reduce((acc, key: string) => {
+      acc[key as DefaultBreakpoints] = Math.round(
+        (breakpoints[key] - cellMargins[0]) /
+          (defaultColumnWidth + cellMargins[0])
+      );
+      return acc;
+    }, {} as Breakpoints<Breakpoint>);
+  }, [props.responsiveColumns, breakpoints, cellMargins]);
+
+  useEffect(() => {
+    if (props.responsiveLayouts) {
+      return;
+    }
+    // If a responsiveLayouts does not exist create one and update the redux state for this
+    // responsive display.
+    const responsiveLayouts = Object.keys(columns).reduce(
+      (acc, key: string) => {
+        acc[key as DefaultBreakpoints] =
+          calculateDefaultLayoutWithHorizontalCompactor(
+            childrenArray,
+            breakpoints[key as DefaultBreakpoints],
+            columns[key as DefaultBreakpoints],
+            cellMargins,
+            cellHeight
+          );
+        return acc;
+      },
+      {} as ResponsiveLayouts<Breakpoint>
+    );
+
+    dispatch(
+      fileDisplaySetResponsiveLayout({
+        file: props.fileId,
+        displayId: props.id,
+        responsiveLayouts,
+        responsiveColumns: columns,
+        responsiveBreakpoints: breakpoints,
+        gridCellMargins: cellMargins,
+        gridCellHeight: cellHeight,
+        gridCellDragEnabled,
+        gridCellResizeEnabled
+      })
+    );
+  }, [
+    dispatch,
+    props.fileId,
+    props.id,
+    props.responsiveLayouts,
+    childrenArray,
+    columns,
+    breakpoints,
+    cellMargins,
+    cellHeight,
+    gridCellDragEnabled,
+    gridCellResizeEnabled
+  ]);
 
   const initialLayouts = React.useMemo(
-    () =>
-      (props.responsiveLayouts ??
-        calculateDefaultLayouts(
-          childrenArray
-        )) as ResponsiveLayouts<Breakpoint>,
-    [props.responsiveLayouts, childrenArray]
+    () => props.responsiveLayouts ?? ({} as ResponsiveLayouts<Breakpoint>),
+    [props.responsiveLayouts]
   );
 
   const { layouts } = useResponsiveLayout({
@@ -189,14 +248,14 @@ export const DisplayResponsiveComponent = (
         style={extendedStyle}
         className="display-responsive-container"
       >
-        {mounted && (
+        {mounted && props.responsiveLayouts && (
           <Responsive
             key={`grid-${props.id}`}
             className="layout"
             layouts={layouts}
             breakpoints={breakpoints}
             cols={columns}
-            rowHeight={Number(props.gridCellHeight ?? defaultRowHeight)}
+            rowHeight={cellHeight}
             margin={cellMargins}
             width={debouncedWidth}
             dragConfig={{
@@ -243,35 +302,6 @@ const DisplayResponsiveWidgetProps = {
   ...WidgetPropType
 };
 
-const calculateDefaultLayouts = (
-  childrenArray: React.ReactElement<PVWidgetComponent>[]
-): ResponsiveLayouts => {
-  return {
-    lg: childrenArray.map((child, i) => ({
-      i: child.props.id,
-      x: (i % 4) * 8,
-      y: Math.floor(i / 4),
-      w: 8,
-      h: 4
-    })) as Layout,
-
-    md: childrenArray.map((child, i) => ({
-      i: child.props.id,
-      x: (i % 2) * 8,
-      y: Math.floor(i / 2),
-      w: 8,
-      h: 4
-    })) as Layout,
-
-    sm: childrenArray.map((child, i) => ({
-      i: child.props.id,
-      x: 0,
-      y: i,
-      w: 8,
-      h: 4
-    })) as Layout
-  };
-};
 export const DisplayResponsive = (
   props: InferWidgetProps<typeof DisplayResponsiveWidgetProps>
 ): JSX.Element => <Widget baseWidget={DisplayResponsiveComponent} {...props} />;

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
@@ -1,11 +1,17 @@
-import React, { useState, useContext, ReactNode, useEffect } from "react";
+import React, {
+  useState,
+  useContext,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useCallback
+} from "react";
 import {
   ResponsiveLayouts,
   Responsive,
   useContainerWidth,
   Breakpoints,
   useResponsiveLayout,
-  DefaultBreakpoints,
   Breakpoint
 } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
@@ -36,8 +42,13 @@ import {
 import { useStyle } from "../../hooks/useStyle";
 import { useDebouncedValue } from "../../hooks/useDebounce";
 import { useDispatch } from "react-redux";
-import { calculateDefaultLayoutWithHorizontalCompactor } from "./displayLayoutUtilities";
+import {
+  calculateDefaultLayoutWithHorizontalCompactor,
+  sameKeys
+} from "./displayLayoutUtilities";
 import { fileDisplaySetResponsiveLayout } from "../../../redux/csState";
+import log from "loglevel";
+import { Dispatch } from "@reduxjs/toolkit";
 
 const widgetName = "displayResponsive";
 
@@ -66,13 +77,13 @@ const DisplayResponsiveProps = {
   gridCellHeight: IntPropOpt
 };
 
+type propsType = InferWidgetProps<typeof DisplayResponsiveProps> & {
+  id: string;
+  fileId: string;
+};
+
 // Display widget that uses react-grid-layout to provide a responsive drag and drop container
-export const DisplayResponsiveComponent = (
-  props: InferWidgetProps<typeof DisplayResponsiveProps> & {
-    id: string;
-    fileId: string;
-  }
-): JSX.Element => {
+export const DisplayResponsiveComponent = (props: propsType): JSX.Element => {
   // Macros specific to this display. Children of this component
   // can set macros by using the updateMacro function on the
   // context.
@@ -93,11 +104,11 @@ export const DisplayResponsiveComponent = (
 
   const cellHeight = Number(props.gridCellHeight ?? defaultRowHeight);
 
-  const updateMacro = React.useCallback((key: string, value: string) => {
+  const updateMacro = useCallback((key: string, value: string) => {
     setDisplayMacros(prev => ({ ...prev, [key]: value }));
   }, []);
 
-  const displayMacroContext = React.useMemo<MacroContextType>(
+  const displayMacroContext = useMemo<MacroContextType>(
     () => ({
       updateMacro,
       macros: {
@@ -111,7 +122,7 @@ export const DisplayResponsiveComponent = (
 
   // Get base style from common CSS
   const style = useStyle(props, widgetName);
-  const extendedStyle = React.useMemo<React.CSSProperties>(
+  const extendedStyle = useMemo<React.CSSProperties>(
     () => ({
       ...style.colors,
       ...style.border,
@@ -130,7 +141,7 @@ export const DisplayResponsiveComponent = (
     number
   ];
 
-  const childrenArray = React.useMemo(
+  const childrenArray = useMemo(
     () =>
       React.Children.toArray(props.children as ReactNode[]).filter(child =>
         React.isValidElement<PVWidgetComponent>(child)
@@ -138,77 +149,78 @@ export const DisplayResponsiveComponent = (
     [props.children]
   );
 
-  const breakpoints = React.useMemo(
+  const breakpoints = useMemo(
     () =>
       (props?.responsiveBreakpoints
         ? props.responsiveBreakpoints
-        : defaultBreakpoints) as Breakpoints<string>,
+        : defaultBreakpoints) as Breakpoints<Breakpoint>,
     [props.responsiveBreakpoints]
   );
 
-  const columns = React.useMemo(() => {
-    if (props.responsiveColumns) {
-      return props.responsiveColumns as Breakpoints<Breakpoint>;
-    }
-
-    return Object.keys(breakpoints).reduce((acc, key: string) => {
-      acc[key as DefaultBreakpoints] = Math.round(
-        (breakpoints[key] - cellMargins[0]) /
-          (defaultColumnWidth + cellMargins[0])
-      );
-      return acc;
-    }, {} as Breakpoints<Breakpoint>);
-  }, [props.responsiveColumns, breakpoints, cellMargins]);
-
-  useEffect(() => {
-    if (props.responsiveLayouts) {
-      return;
-    }
-    // If a responsiveLayouts does not exist create one and update the redux state for this
-    // responsive display.
-    const responsiveLayouts = Object.keys(columns).reduce(
-      (acc, key: string) => {
-        acc[key as DefaultBreakpoints] =
-          calculateDefaultLayoutWithHorizontalCompactor(
-            childrenArray,
-            breakpoints[key as DefaultBreakpoints],
-            columns[key as DefaultBreakpoints],
-            cellMargins,
-            cellHeight
-          );
-        return acc;
-      },
-      {} as ResponsiveLayouts<Breakpoint>
+  // Check that the breakpoints are consistent, between breakpoints, columns and layouts
+  const areBreakpointsConsistent = useMemo(
+    () =>
+      (!props.responsiveColumns ||
+        sameKeys(breakpoints, props.responsiveColumns)) &&
+      (!props.responsiveLayouts ||
+        sameKeys(breakpoints, props.responsiveLayouts)),
+    [props.responsiveColumns, props.responsiveLayouts, breakpoints]
+  );
+  if (!areBreakpointsConsistent) {
+    log.error(
+      `Inconsistent breakpoint keys between breakpoints, columns, and layouts. Expected keys: ${Object.keys(breakpoints).join(", ")}. Falling back to defaults.`
     );
+  }
 
-    dispatch(
-      fileDisplaySetResponsiveLayout({
-        file: props.fileId,
-        displayId: props.id,
-        responsiveLayouts,
-        responsiveColumns: columns,
-        responsiveBreakpoints: breakpoints,
-        gridCellMargins: cellMargins,
-        gridCellHeight: cellHeight,
+  const columns: Breakpoints<Breakpoint> = useMemo(
+    () =>
+      calculateColumns(
+        props.responsiveColumns as Breakpoints<Breakpoint>,
+        areBreakpointsConsistent,
+        breakpoints,
+        cellMargins
+      ),
+    [
+      props.responsiveColumns,
+      breakpoints,
+      cellMargins,
+      areBreakpointsConsistent
+    ]
+  );
+
+  useEffect(
+    () =>
+      calculateLayout(
+        props.id,
+        props.fileId,
+        props.responsiveLayouts as ResponsiveLayouts<Breakpoint>,
+        areBreakpointsConsistent,
+        breakpoints,
+        childrenArray,
+        columns,
+        cellMargins,
+        cellHeight,
+        dispatch,
         gridCellDragEnabled,
         gridCellResizeEnabled
-      })
-    );
-  }, [
-    dispatch,
-    props.fileId,
-    props.id,
-    props.responsiveLayouts,
-    childrenArray,
-    columns,
-    breakpoints,
-    cellMargins,
-    cellHeight,
-    gridCellDragEnabled,
-    gridCellResizeEnabled
-  ]);
+      ),
+    [
+      dispatch,
+      props.fileId,
+      props.id,
+      props.responsiveLayouts,
+      childrenArray,
+      columns,
+      breakpoints,
+      cellMargins,
+      cellHeight,
+      gridCellDragEnabled,
+      gridCellResizeEnabled,
+      areBreakpointsConsistent
+    ]
+  );
 
-  const initialLayouts = React.useMemo(
+  const initialLayouts = useMemo(
     () => props.responsiveLayouts ?? ({} as ResponsiveLayouts<Breakpoint>),
     [props.responsiveLayouts]
   );
@@ -221,23 +233,8 @@ export const DisplayResponsiveComponent = (
   });
 
   // Wrap the child components in a div keyed by the child id. The key MUST map to the i field of Layout item for the component.
-  const gridChildren = React.useMemo(
-    () =>
-      childrenArray.map(child => {
-        const id = child.props.id;
-        if (!id) {
-          throw new Error("All grid items must have a stable id");
-        }
-
-        return (
-          <div
-            key={id}
-            style={{ cursor: gridCellDragEnabled ? "grab" : "default" }}
-          >
-            {child}
-          </div>
-        );
-      }),
+  const gridChildren = useMemo(
+    () => wrapChildrenForGridLayout(childrenArray, gridCellDragEnabled),
     [childrenArray, gridCellDragEnabled]
   );
 
@@ -307,3 +304,98 @@ export const DisplayResponsive = (
 ): JSX.Element => <Widget baseWidget={DisplayResponsiveComponent} {...props} />;
 
 registerWidget(DisplayResponsive, DisplayResponsiveWidgetProps, widgetName);
+
+const calculateLayout = (
+  id: string,
+  fileId: string,
+  responsiveLayouts: ResponsiveLayouts<Breakpoint>,
+  areBreakpointsConsistent: boolean,
+  breakpoints: Breakpoints<string>,
+  childrenArray: React.ReactElement<
+    PVWidgetComponent,
+    string | React.JSXElementConstructor<any>
+  >[],
+  columns: Breakpoints<string>,
+  cellMargins: [number, number],
+  cellHeight: number,
+  dispatch: Dispatch,
+  gridCellDragEnabled: boolean,
+  gridCellResizeEnabled: boolean
+): void => {
+  if (responsiveLayouts && areBreakpointsConsistent) {
+    return;
+  }
+
+  // If a responsiveLayouts does not exist create one and update the redux state for this
+  // responsive display.
+  const computedResponsiveLayouts = Object.keys(breakpoints).reduce(
+    (acc, key: string) => {
+      acc[key as Breakpoint] = calculateDefaultLayoutWithHorizontalCompactor(
+        childrenArray,
+        breakpoints[key as Breakpoint],
+        columns[key as Breakpoint],
+        cellMargins,
+        cellHeight
+      );
+      return acc;
+    },
+    {} as ResponsiveLayouts<Breakpoint>
+  );
+
+  dispatch(
+    fileDisplaySetResponsiveLayout({
+      file: fileId,
+      displayId: id,
+      responsiveLayouts: computedResponsiveLayouts,
+      responsiveColumns: columns,
+      responsiveBreakpoints: breakpoints,
+      gridCellMargins: cellMargins,
+      gridCellHeight: cellHeight,
+      gridCellDragEnabled,
+      gridCellResizeEnabled
+    })
+  );
+};
+
+const calculateColumns = (
+  responsiveColumns: Breakpoints<Breakpoint>,
+  areBreakpointsConsistent: boolean,
+  breakpoints: Breakpoints<string>,
+  cellMargins: [number, number]
+): Breakpoints<string> => {
+  if (responsiveColumns && areBreakpointsConsistent) {
+    return responsiveColumns as Breakpoints<Breakpoint>;
+  }
+
+  return Object.keys(breakpoints).reduce((acc, key: Breakpoint) => {
+    acc[key] = Math.round(
+      (breakpoints[key] - cellMargins[0]) /
+        (defaultColumnWidth + cellMargins[0])
+    );
+    return acc;
+  }, {} as Breakpoints<Breakpoint>);
+};
+
+const wrapChildrenForGridLayout = (
+  childrenArray: React.ReactElement<
+    PVWidgetComponent,
+    string | React.JSXElementConstructor<any>
+  >[],
+  gridCellDragEnabled: boolean
+) => {
+  return childrenArray.map(child => {
+    const id = child.props.id;
+    if (!id) {
+      throw new Error("All grid items must have a stable id");
+    }
+
+    return (
+      <div
+        key={id}
+        style={{ cursor: gridCellDragEnabled ? "grab" : "default" }}
+      >
+        {child}
+      </div>
+    );
+  });
+};

--- a/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayResponsive.tsx
@@ -46,7 +46,7 @@ import {
   calculateDefaultLayoutWithHorizontalCompactor,
   sameKeys
 } from "./displayLayoutUtilities";
-import { fileDisplaySetResponsiveLayout } from "../../../redux/csState";
+import { fileDisplaySetResponsiveLayout } from "../../../redux/slices/fileCacheSlice";
 import log from "loglevel";
 import { Dispatch } from "@reduxjs/toolkit";
 

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -445,7 +445,8 @@ async function bobParseTabs(
   simpleParsers: ParserDict,
   complexParsers: ComplexParserDict,
   filepath?: string,
-  macros?: MacroMap
+  macros?: MacroMap,
+  fileId?: string
 ): Promise<any> {
   const tabs = await Promise.all(
     props.tab.map(async (tab: any) => {
@@ -467,7 +468,8 @@ async function bobParseTabs(
               false,
               OPI_PATCHERS(BOB_SIMPLE_PARSERS, BOB_COMPLEX_PARSERS),
               filepath,
-              macros
+              macros,
+              fileId
             );
           })
         );
@@ -698,7 +700,8 @@ export async function parseBob(
   xmlString: string,
   defaultProtocol: string,
   filepath: string,
-  macros?: MacroMap
+  macros?: MacroMap,
+  fileId?: string
 ): Promise<WidgetDescription> {
   // Convert it to a "compact format"
   const compactJSON = xml2js(xmlString, {
@@ -757,7 +760,8 @@ export async function parseBob(
         simpleParsers,
         complexParsers,
         filepath,
-        macros
+        macros,
+        fileId
       )
   };
 
@@ -770,7 +774,8 @@ export async function parseBob(
     false,
     OPI_PATCHERS(BOB_SIMPLE_PARSERS, BOB_COMPLEX_PARSERS),
     filepath,
-    macros
+    macros,
+    fileId
   );
 
   displayWidget.position = newRelativePosition(

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -253,6 +253,7 @@ export const EmbeddedDisplay = (
       {
         type: "display",
         id: `display_${crypto.randomUUID()}`,
+        fileId: props?.file?.path,
         position: resolvedProps.position,
         backgroundColor:
           selectedDescription.backgroundColor ?? newColor("rgb(255,255,255"),

--- a/src/ui/widgets/EmbeddedDisplay/jsonParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/jsonParser.ts
@@ -147,7 +147,8 @@ function jsonGetTargetWidget(props: any): {
 export async function parseObject(
   object: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
   defaultProtocol: string,
-  path?: string
+  path?: string,
+  fileId?: string
 ): Promise<WidgetDescription> {
   const simpleParsers: ParserDict = {
     ...SIMPLE_PARSERS,
@@ -168,7 +169,9 @@ export async function parseObject(
     COMPLEX_PARSERS,
     true,
     [],
-    path
+    path,
+    undefined,
+    fileId
   );
 }
 
@@ -180,7 +183,13 @@ export async function parseObject(
 export async function parseJson(
   jsonString: string,
   defaultProtocol: string,
-  path: string
+  path: string,
+  fileId?: string
 ): Promise<WidgetDescription> {
-  return await parseObject(JSON.parse(jsonString), defaultProtocol, path);
+  return await parseObject(
+    JSON.parse(jsonString),
+    defaultProtocol,
+    path,
+    fileId
+  );
 }

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -974,7 +974,8 @@ export const OPI_PATCHERS = (
 export async function parseOpi(
   xmlString: string,
   defaultProtocol: string,
-  filepath: string
+  filepath: string,
+  fileId?: string
 ): Promise<WidgetDescription> {
   // Convert it to a "compact format"
   const compactJSON = xml2js(xmlString, {
@@ -1015,7 +1016,9 @@ export async function parseOpi(
     complexParsers,
     false,
     OPI_PATCHERS(OPI_SIMPLE_PARSERS, OPI_COMPLEX_PARSERS),
-    filepath
+    filepath,
+    undefined,
+    fileId
   );
 
   displayWidget.position = newRelativePosition(

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -183,7 +183,8 @@ export async function parseWidget(
   passThrough: boolean,
   patchFunctions: PatchFunction[],
   filepath?: string,
-  macros?: MacroMap
+  macros?: MacroMap,
+  fileId?: string
 ): Promise<WidgetDescription> {
   const targetWidget = getTargetWidget(props);
   const allowedProps = { position: PositionProp, ...targetWidget?.widgetProps };
@@ -216,7 +217,8 @@ export async function parseWidget(
         passThrough,
         patchFunctions,
         filepath,
-        macros
+        macros,
+        fileId
       );
     })
   );
@@ -236,6 +238,8 @@ export async function parseWidget(
   if (widgetDescription.wrapWords === undefined) {
     widgetDescription.wrapWords = true;
   }
+
+  widgetDescription.fileId = fileId ?? filepath ?? "";
 
   return widgetDescription;
 }

--- a/src/ui/widgets/Tabs/tabContainer.test.tsx
+++ b/src/ui/widgets/Tabs/tabContainer.test.tsx
@@ -27,7 +27,11 @@ describe("<TabContainer>", (): void => {
     const { findByText } = await act(() => {
       return render(
         <Provider store={store()}>
-          <TabContainerComponent tabs={[{ name: "one", children: child }]} />
+          <TabContainerComponent
+            id={"deviceId1"}
+            fileId={"fileId1"}
+            tabs={[{ name: "one", children: child }]}
+          />
         </Provider>
       );
     });
@@ -45,7 +49,11 @@ describe("<TabContainer>", (): void => {
     const { findByText } = await act(() => {
       return render(
         <Provider store={store()}>
-          <TabContainerComponent tabs={[{ name: "one", children: child }]} />
+          <TabContainerComponent
+            id={"deviceId1"}
+            fileId={"fileId1"}
+            tabs={[{ name: "one", children: child }]}
+          />
         </Provider>
       );
     });
@@ -72,6 +80,8 @@ describe("<TabContainer>", (): void => {
       return render(
         <Provider store={store()}>
           <TabContainerComponent
+            id={"deviceId1"}
+            fileId={"fileId1"}
             tabs={[
               { name: "one", children: child1 },
               { name: "two", children: child2 }

--- a/src/ui/widgets/Tabs/tabContainer.tsx
+++ b/src/ui/widgets/Tabs/tabContainer.tsx
@@ -43,7 +43,10 @@ export const TabContainerProps = {
 };
 
 export const TabContainerComponent = (
-  props: InferWidgetProps<typeof TabContainerProps>
+  props: InferWidgetProps<typeof TabContainerProps> & {
+    fileId: string;
+    id: string;
+  }
 ): JSX.Element => {
   const { colors } = useStyle(props, widgetName);
   const {
@@ -64,7 +67,8 @@ export const TabContainerComponent = (
           name: tab.name,
           children: widgetDescriptionToComponent({
             type: "display",
-            id: "123",
+            id: props?.id ?? `tabContainer_${crypto.randomUUID()}`,
+            fileId: props?.fileId,
             position: newRelativePosition(
               "0px",
               `${tabHeight}px`,
@@ -85,7 +89,15 @@ export const TabContainerComponent = (
         };
       }
     });
-  }, [props.tabs, colors?.backgroundColor, tabHeight, width, height]);
+  }, [
+    props.tabs,
+    colors?.backgroundColor,
+    tabHeight,
+    width,
+    height,
+    props.id,
+    props.fileId
+  ]);
 
   return (
     <TabBar

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -11,6 +11,7 @@ import { BorderStyle, newBorder } from "../../types/border";
 export interface WidgetDescription {
   type: string;
   id: string;
+  fileId: string;
   // All other component properties
   [x: string]: any;
   children?: WidgetDescription[];
@@ -18,6 +19,7 @@ export interface WidgetDescription {
 const ERROR_WIDGET: WidgetDescription = {
   type: "label",
   id: `label_${crypto.randomUUID()}`,
+  fileId: "NO_FILE",
   position: newRelativePosition(),
   font: newFont(16, FontStyle.Bold),
   backgroundColor: ColorUtils.TRANSPARENT,


### PR DESCRIPTION
This adds the capability to automatically layout react grid layout displays using pixel placed displays.
At the heart of it is `calculateDefaultLayout` which takes a set of child items a screen width, columns and cell height and computes a first pass layout using the position and width of the child items. Child items are wrapped if the screen width is too narrow to accommodate them.  The RGL verticalCompactor is then used to layout and resolve collisons in the y (columns). In addition for responsive screens the horizontalCompactor is also used.

Once a layout has been computed it is dispatched to update the file state, which causes a re-render using the new layout as the updated props are passed down.

I've moved the FileCache into a separate slice to improve separation of concerns.