### PR TITLE
Expose types, utilities, etc. for parsing `DTypes`

### DIFF
--- a/src/types/dtypes/index.ts
+++ b/src/types/dtypes/index.ts
@@ -3,4 +3,4 @@ export { type DDisplay, newDDisplay } from "./dDisplay";
 export { type DRange, newDRange } from "./dRange";
 export { type DTime, newDTime, dTimeToDate, dTimeNow } from "./dTime";
 export * from "./dType";
-export { type DTypeValue } from "./dTypeValue";
+export { type DTypeValue, type NumberArray } from "./dTypeValue";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,5 +5,12 @@ export type { Font } from "./font";
 export { FontStyle } from "./font";
 export { BorderStyle } from "./border";
 export type { Border } from "./border";
-export type { DType } from "./dtypes";
+export {
+  type DType,
+  newDType,
+  dTypeGetType,
+  dTypeGetStringValue,
+  dTypeGetDoubleValue,
+  dTypeCoerceString
+} from "./dtypes";
 export { resolveMacros } from "./macros";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,8 @@ export { BorderStyle } from "./border";
 export type { Border } from "./border";
 export {
   type DType,
+  type DtypeValues,
+  type NumberArray,
   newDType,
   dTypeGetType,
   dTypeGetStringValue,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export {
   dTypeGetType,
   dTypeGetStringValue,
   dTypeGetDoubleValue,
-  dTypeCoerceString
+  dTypeGetArrayValue,
+  dTypeCoerceString,
+  dTypeByteArrToString
 } from "./dtypes";
 export { resolveMacros } from "./macros";


### PR DESCRIPTION
Fixes #204 

Additional utilities exposed for parsing `DTypes`, including:
- newDType,
- dTypeGetType,
- dTypeGetStringValue,
- dTypeGetDoubleValue,
- dTypeGetArrayValue,
- dTypeCoerceString,
- dTypeByteArrToString