### PR TITLE
Adjust svg viewbox sizing

### DIFF
--- a/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
+++ b/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<LineComponent /> > matches snapshot 1`] = `
   <svg
     display="block"
     overflow="visible"
-    viewBox="0 0 100% 100%"
+    viewBox="0 0 20 15"
     xmlns="http://www.w3.org/2000/svg"
   >
     <polyline
@@ -15,7 +15,7 @@ exports[`<LineComponent /> > matches snapshot 1`] = `
       stroke="rgba(200,1,60,1)"
       stroke-dasharray="0"
       stroke-width="4"
-      transform="rotation(45,0,0)"
+      transform="rotate(45,0,0)"
     />
   </svg>
 </DocumentFragment>

--- a/src/ui/widgets/Line/line.test.tsx
+++ b/src/ui/widgets/Line/line.test.tsx
@@ -58,13 +58,13 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 20 25");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
 
     expect(lines[0].props.stroke).toEqual("rgba(200,1,60,1)");
     expect(lines[0].props.strokeWidth).toEqual(3);
-    expect(lines[0].props.transform).toEqual("rotation(0,0,0)");
+    expect(lines[0].props.transform).toEqual("rotate(0,0,0)");
     expect(lines[0].props.points).toEqual("1,10 15,20 4,15 ");
   });
 
@@ -83,13 +83,13 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 20 25");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
 
     expect(lines[0].props.stroke).toEqual("rgba(0,150,60,1)");
     expect(lines[0].props.strokeWidth).toEqual(3);
-    expect(lines[0].props.transform).toEqual("rotation(0,0,0)");
+    expect(lines[0].props.transform).toEqual("rotate(0,0,0)");
     expect(lines[0].props.points).toEqual("1,10 15,20 4,15 ");
   });
 
@@ -113,13 +113,13 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 30 20");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
 
     expect(lines[0].props.stroke).toEqual("transparent");
     expect(lines[0].props.strokeWidth).toEqual(15);
-    expect(lines[0].props.transform).toEqual("rotation(45,0,0)");
+    expect(lines[0].props.transform).toEqual("rotate(45,0,0)");
     expect(lines[0].props.points).toEqual("16,4 25,10 4,15 ");
   });
 
@@ -145,7 +145,7 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 30 20");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
     const marker = lines[0].children as Array<ReactTestRendererJSON>;
@@ -184,7 +184,7 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 30 20");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
     const marker = lines[0].children as Array<ReactTestRendererJSON>;

--- a/src/ui/widgets/Line/line.tsx
+++ b/src/ui/widgets/Line/line.tsx
@@ -8,11 +8,13 @@ import {
   BoolPropOpt,
   PointsProp,
   MacrosPropOpt,
-  IntPropOpt
+  IntPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 import { Point } from "../../../types/points";
 import { useStyle } from "../../hooks/useStyle";
+import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const widgetName = "line";
 
@@ -28,7 +30,9 @@ const LineProps = {
   rotationAngle: FloatPropOpt,
   arrows: FloatPropOpt,
   arrowLength: FloatPropOpt,
-  fillArrow: BoolPropOpt
+  fillArrow: BoolPropOpt,
+  width: StringPropOpt,
+  height: StringPropOpt
 };
 
 export type LineComponentProps = InferWidgetProps<typeof LineProps> &
@@ -47,7 +51,9 @@ export const LineComponent = (props: LineComponentProps): JSX.Element => {
     fillArrow = true,
     lineWidth = 3,
     lineColor,
-    lineStyle = 0
+    lineStyle = 0,
+    width = WIDGET_DEFAULT_SIZES["polyline"][0],
+    height = WIDGET_DEFAULT_SIZES["polyline"][1]
   } = newProps as LineComponentProps;
 
   const color = transparent
@@ -69,7 +75,7 @@ export const LineComponent = (props: LineComponentProps): JSX.Element => {
     }
   })();
 
-  const transform = `rotation(${rotationAngle},0,0)`;
+  const transform = `rotate(${rotationAngle},0,0)`;
 
   // Each marker definition needs a unique ID or colours overlap
   const uid = crypto.randomUUID();
@@ -159,7 +165,7 @@ export const LineComponent = (props: LineComponentProps): JSX.Element => {
     return (
       <svg
         display={"block"}
-        viewBox={`0 0 100% 100%`}
+        viewBox={`0 0 ${width} ${height}`}
         xmlns="http://www.w3.org/2000/svg"
         overflow={"visible"}
       >

--- a/src/ui/widgets/Polygon/polygon.test.tsx
+++ b/src/ui/widgets/Polygon/polygon.test.tsx
@@ -45,13 +45,13 @@ describe("<PolygonComponent />", (): void => {
     };
 
     const svg = PolygonRenderer(polygonProps);
-    expect(svg.props.viewBox).toEqual("0 0 100% 100%");
+    expect(svg.props.viewBox).toEqual("0 0 20 10");
 
     const polygons = svg.children as Array<ReactTestRendererJSON>;
 
     expect(polygons[0].props.points).toEqual("1,10 15,20 ");
     expect(polygons[0].props.fill).toEqual("rgba(200,1,60,1)");
-    expect(polygons[0].props.transform).toEqual("rotation(0,0,0)");
+    expect(polygons[0].props.transform).toEqual("rotate(0,0,0)");
     expect(polygons[0].props.stroke).toEqual("rgba(0,1,255,1)");
     expect(polygons[0].props.strokeWidth).toEqual(2);
   });

--- a/src/ui/widgets/Polygon/polygon.tsx
+++ b/src/ui/widgets/Polygon/polygon.tsx
@@ -9,10 +9,12 @@ import {
   IntPropOpt,
   BoolPropOpt,
   PointsPropOpt,
-  MacrosPropOpt
+  MacrosPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { Point } from "../../../types/points";
 import { useStyle } from "../../hooks/useStyle";
+import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const widgetName = "polygon";
 
@@ -24,7 +26,9 @@ const PolygonProps = {
   backgroundColor: ColorPropOpt,
   points: PointsPropOpt,
   rotationAngle: IntPropOpt,
-  transparent: BoolPropOpt
+  transparent: BoolPropOpt,
+  width: StringPropOpt,
+  height: StringPropOpt
 };
 
 type PolygonComponentProps = InferWidgetProps<typeof PolygonProps> & {
@@ -40,7 +44,9 @@ export const PolygonComponent = (props: PolygonComponentProps): JSX.Element => {
   const {
     lineWidth = 3,
     points,
-    rotationAngle = 0
+    rotationAngle = 0,
+    width = WIDGET_DEFAULT_SIZES["polygon"][0],
+    height = WIDGET_DEFAULT_SIZES["polygon"][1]
   } = newProps as PolygonComponentProps;
   //Loop over points and convert to string for svg
   let coordinates = "";
@@ -52,7 +58,7 @@ export const PolygonComponent = (props: PolygonComponentProps): JSX.Element => {
 
   return (
     <svg
-      viewBox={`0 0 100% 100%`}
+      viewBox={`0 0 ${width} ${height}`}
       xmlns="http://www.w3.org/2000/svg"
       overflow={"visible"}
     >
@@ -61,7 +67,7 @@ export const PolygonComponent = (props: PolygonComponentProps): JSX.Element => {
         stroke={customColors?.lineColor}
         strokeWidth={lineWidth}
         fill={colors?.backgroundColor}
-        transform={`rotation(${rotationAngle},0,0)`}
+        transform={`rotate(${rotationAngle},0,0)`}
         points={coordinates}
       />
     </svg>


### PR DESCRIPTION
Correctly sizes viewboxes for the polyline and polygon widgets, which fixes an issue seen in the Daedalus i19 screens caused by svg boxes covering up symbols.

Also corrected a small bug where the transform was set to "rotation" instead of "rotate"