### PR TITLE
Enable converting display types for Quick Screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondlightsource/cs-web-lib",
-      "version": "0.10.20",
+      "version": "0.10.21",
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
   "type": "module",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/redux/slices/fileCacheSlice.test.ts
+++ b/src/redux/slices/fileCacheSlice.test.ts
@@ -15,7 +15,11 @@ import fileCacheReducer, {
   displayInstanceUpdateResponsiveLayout,
   selectDisplayInstance,
   selectDisplayInstanceByFileAndMacros,
-  displayInstanceUpdateGridLayout
+  displayInstanceUpdateGridLayout,
+  convertDisplayInstanceType,
+  clearLayoutProperties,
+  convertDisplayType,
+  normaliseChildren
 } from "./fileCacheSlice";
 
 const initialState: FileCacheState = {
@@ -739,5 +743,165 @@ describe("displayInstanceUpdateResponsiveLayout", () => {
     );
 
     expect(result).toEqual(state);
+  });
+});
+
+describe("convertDisplayInstanceType", () => {
+  it("does nothing if display instance not found", () => {
+    const result = fileCacheReducer(
+      initialState,
+      convertDisplayInstanceType({
+        uuid: "missing",
+        displayType: "displayGridLayout"
+      })
+    );
+
+    expect(result).toEqual(initialState);
+  });
+  it("correctly converts a display to new type", () => {
+    const result = fileCacheReducer(
+      initialState,
+      convertDisplayInstanceType({
+        uuid: "UUID1",
+        displayType: "displayGridLayout"
+      })
+    );
+
+    const converted = result.displayInstanceCache.UUID1.description;
+
+    expect(converted.type).toBe("displayGridLayout");
+    expect(converted.gridCellDragEnabled).toBe(true);
+    expect(converted.gridCellResizeEnabled).toBe(true);
+  });
+});
+
+describe("clearLayoutProperties", () => {
+  it("clears all specificed properties on grid display", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "myFile",
+      type: "displayGridLayout",
+      gridLayout: [],
+      gridLayoutColumns: 12,
+      gridCellMargins: [5, 5],
+      gridCellHeight: 30,
+      gridCellDragEnabled: true,
+      gridCellResizeEnabled: true
+    };
+
+    clearLayoutProperties(display);
+
+    expect(display.gridLayout).toBeUndefined();
+    expect(display.gridLayoutColumns).toBeUndefined();
+    expect(display.gridCellMargins).toBeUndefined();
+    expect(display.gridCellHeight).toBeUndefined();
+    expect(display.gridCellDragEnabled).toBeUndefined();
+    expect(display.gridCellResizeEnabled).toBeUndefined();
+  });
+  it("clears all specificed properties on responsive display", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "myFile",
+      type: "displayGridLayout",
+      gridLayoutColumns: 12,
+      gridCellMargins: [5, 5],
+      gridCellHeight: 33,
+      gridCellDragEnabled: false,
+      gridCellResizeEnabled: true,
+      responsiveLayouts: {},
+      responsiveBreakpoints: {},
+      responsiveColumns: {}
+    };
+
+    clearLayoutProperties(display);
+
+    expect(display.gridLayoutColumns).toBeUndefined();
+    expect(display.gridCellMargins).toBeUndefined();
+    expect(display.gridCellHeight).toBeUndefined();
+    expect(display.gridCellDragEnabled).toBeUndefined();
+    expect(display.gridCellResizeEnabled).toBeUndefined();
+    expect(display.responsiveLayouts).toBeUndefined();
+    expect(display.responsiveBreakpoints).toBeUndefined();
+    expect(display.responsiveColumns).toBeUndefined();
+  });
+});
+
+describe("convertDisplayType()", () => {
+  it("does nothing if no display type", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "file",
+      type: "display"
+    };
+
+    expect(convertDisplayType(display, "")).toBe(display);
+  });
+  it("does nothing if display is already specified type", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "file",
+      type: "display"
+    };
+
+    expect(convertDisplayType(display, "display")).toBe(display);
+  });
+  it("converts the display to the correct type", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "file",
+      type: "display"
+    };
+
+    const converted = convertDisplayType(display, "displayResponsive");
+
+    expect(converted.type).toBe("displayResponsive");
+    expect(converted.gridCellDragEnabled).toBe(true);
+    expect(converted.gridCellResizeEnabled).toBe(true);
+  });
+});
+
+describe("normaliseChildren()", () => {
+  it("does nothing if child has no position", () => {
+    const display: WidgetDescription = {
+      id: "display",
+      fileId: "file",
+      type: "display",
+      children: [
+        {
+          id: "child",
+          fileId: "file",
+          type: "shape"
+        }
+      ]
+    };
+
+    normaliseChildren(display);
+
+    expect(display.children?.[0].position).toBeUndefined();
+  });
+  it("sets positions to 0px/100%", () => {
+    const display: WidgetDescription = {
+      id: "file1",
+      fileId: "file",
+      type: "display",
+      children: [
+        {
+          id: "shape1",
+          fileId: "file",
+          type: "shape",
+          position: newAbsolutePosition("10", "20", "30", "40"),
+          backgroundColor: ColorUtils.WHITE
+        }
+      ]
+    };
+
+    normaliseChildren(display);
+
+    expect(display.children?.[0].position).toMatchObject({
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    });
   });
 });

--- a/src/redux/slices/fileCacheSlice.ts
+++ b/src/redux/slices/fileCacheSlice.ts
@@ -364,9 +364,9 @@ export const fileComparator = (
 /**
  * Sets position of Child and dimensions inside parent
  * react-grid-item
- * @param display 
+ * @param display
  */
-function normaliseChildren(display: WidgetDescription) {
+export function normaliseChildren(display: WidgetDescription) {
   display.children?.forEach(child => {
     if (!child.position) return;
     child.position = {
@@ -382,17 +382,17 @@ function normaliseChildren(display: WidgetDescription) {
 /**
  * Changes between display, displayGridLayout and DisplayResponsive
  * widget types
- * @param display 
- * @param displayType 
- * @returns 
+ * @param display
+ * @param displayType
+ * @returns
  */
-function convertDisplayType(
+export function convertDisplayType(
   display: WidgetDescription,
   displayType: string
 ): WidgetDescription {
   //If no conversion passed in, don't do anything
   if (!displayType || displayType === display.type) return display;
-  
+
   const newDisplay = { ...display };
   // Clear old properties
   newDisplay.type = displayType;
@@ -407,9 +407,9 @@ function convertDisplayType(
 /**
  * Clears grid layout and responsive properties from
  * a widget in preparation to reset
- * @param display 
+ * @param display
  */
-function clearLayoutProperties(display: WidgetDescription) {
+export function clearLayoutProperties(display: WidgetDescription) {
   delete display.gridLayout;
   delete display.gridLayoutColumns;
   delete display.gridCellMargins;

--- a/src/redux/slices/fileCacheSlice.ts
+++ b/src/redux/slices/fileCacheSlice.ts
@@ -120,17 +120,7 @@ const fileCacheSlice = createSlice({
       display.gridCellDragEnabled = gridCellDragEnabled;
       display.gridCellResizeEnabled = gridCellResizeEnabled;
 
-      display.children?.forEach(c => {
-        if (c.position) {
-          c.position = {
-            ...c.position,
-            x: "0",
-            y: "0",
-            width: "100%",
-            height: "100%"
-          };
-        }
-      });
+      normaliseChildren(display);
     },
     displayInstanceUpdateGridLayout(
       state,
@@ -201,17 +191,7 @@ const fileCacheSlice = createSlice({
         display.position.width = "100%";
       }
 
-      display.children?.forEach(c => {
-        if (c.position) {
-          c.position = {
-            ...c.position,
-            x: "0",
-            y: "0",
-            width: "100%",
-            height: "100%"
-          };
-        }
-      });
+      normaliseChildren(display);
     },
 
     displayInstanceUpdateResponsiveLayout(
@@ -269,6 +249,23 @@ const fileCacheSlice = createSlice({
 
         state.displayInstanceIndex[hash] = uuid;
       }
+    },
+    convertDisplayInstanceType(state, action) {
+      const { uuid, file, macros, displayType } = action.payload;
+      let id = uuid;
+      if (!id) {
+        const hash = `${file}::${stringify(macros)}`;
+        id = state.displayInstanceIndex[hash];
+      }
+      const instance = state.displayInstanceCache[id];
+
+      if (!instance) return;
+
+      instance.description = convertDisplayType(
+        instance.description,
+        displayType
+      );
+      state.displayInstanceCache[id] = instance;
     }
   },
   selectors: {
@@ -285,7 +282,8 @@ export const {
   displayInstanceSetResponsiveLayout,
   displayInstanceUpdateGridLayout,
   displayInstanceUpdateResponsiveLayout,
-  createDisplayInstanceFromFile
+  createDisplayInstanceFromFile,
+  convertDisplayInstanceType
 } = fileCacheSlice.actions;
 
 export default fileCacheSlice.reducer;
@@ -362,3 +360,65 @@ export const fileComparator = (
   }
   return true;
 };
+
+function clearLayoutProperties(display: WidgetDescription) {
+  delete display.gridLayout;
+  delete display.gridLayoutColumns;
+  delete display.gridCellMargins;
+  delete display.gridCellHeight;
+  delete display.gridCellDragEnabled;
+  delete display.gridCellResizeEnabled;
+
+  delete display.responsiveLayouts;
+  delete display.responsiveBreakpoints;
+  delete display.responsiveColumns;
+}
+
+function normaliseChildren(display: WidgetDescription) {
+  display.children?.forEach(child => {
+    if (!child.position) return;
+    child.position = {
+      ...child.position,
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    };
+  });
+}
+
+function convertDisplayType(
+  display: WidgetDescription,
+  displayType: string
+): WidgetDescription {
+  //If no conversion passed in, don't do anything
+  if (!displayType || displayType === display.type) return display;
+  
+  const newDisplay = { ...display };
+  // Clear old properties
+  newDisplay.type = displayType;
+  clearLayoutProperties(newDisplay);
+
+  switch (displayType) {
+    case "display":
+      break;
+    case "displayGridLayout":
+      newDisplay.gridCellDragEnabled = true;
+      newDisplay.gridCellResizeEnabled = true;
+      newDisplay.gridCellMargins = [6, 6];
+      newDisplay.gridCellHeight = 15;
+      newDisplay.gridLayoutColumns = 14;
+      //newDisplay.gridLayout = calculateDefaultLayout(...);
+      break;
+    case "displayResponsive":
+      newDisplay.gridCellDragEnabled = true;
+      newDisplay.gridCellResizeEnabled = true;
+      newDisplay.gridCellMargins = [6, 6];
+      newDisplay.gridCellHeight = 15;
+      newDisplay.responsiveColumns = 14;
+      newDisplay.responsiveBreakpoints = 3;
+      break;
+  }
+  normaliseChildren(newDisplay);
+  return newDisplay;
+}

--- a/src/redux/slices/fileCacheSlice.ts
+++ b/src/redux/slices/fileCacheSlice.ts
@@ -361,19 +361,11 @@ export const fileComparator = (
   return true;
 };
 
-function clearLayoutProperties(display: WidgetDescription) {
-  delete display.gridLayout;
-  delete display.gridLayoutColumns;
-  delete display.gridCellMargins;
-  delete display.gridCellHeight;
-  delete display.gridCellDragEnabled;
-  delete display.gridCellResizeEnabled;
-
-  delete display.responsiveLayouts;
-  delete display.responsiveBreakpoints;
-  delete display.responsiveColumns;
-}
-
+/**
+ * Sets position of Child and dimensions inside parent
+ * react-grid-item
+ * @param display 
+ */
 function normaliseChildren(display: WidgetDescription) {
   display.children?.forEach(child => {
     if (!child.position) return;
@@ -387,6 +379,13 @@ function normaliseChildren(display: WidgetDescription) {
   });
 }
 
+/**
+ * Changes between display, displayGridLayout and DisplayResponsive
+ * widget types
+ * @param display 
+ * @param displayType 
+ * @returns 
+ */
 function convertDisplayType(
   display: WidgetDescription,
   displayType: string
@@ -398,27 +397,27 @@ function convertDisplayType(
   // Clear old properties
   newDisplay.type = displayType;
   clearLayoutProperties(newDisplay);
+  if (displayType === "display") return newDisplay;
+  newDisplay.gridCellDragEnabled = true;
+  newDisplay.gridCellResizeEnabled = true;
 
-  switch (displayType) {
-    case "display":
-      break;
-    case "displayGridLayout":
-      newDisplay.gridCellDragEnabled = true;
-      newDisplay.gridCellResizeEnabled = true;
-      newDisplay.gridCellMargins = [6, 6];
-      newDisplay.gridCellHeight = 15;
-      newDisplay.gridLayoutColumns = 14;
-      //newDisplay.gridLayout = calculateDefaultLayout(...);
-      break;
-    case "displayResponsive":
-      newDisplay.gridCellDragEnabled = true;
-      newDisplay.gridCellResizeEnabled = true;
-      newDisplay.gridCellMargins = [6, 6];
-      newDisplay.gridCellHeight = 15;
-      newDisplay.responsiveColumns = 14;
-      newDisplay.responsiveBreakpoints = 3;
-      break;
-  }
-  normaliseChildren(newDisplay);
   return newDisplay;
+}
+
+/**
+ * Clears grid layout and responsive properties from
+ * a widget in preparation to reset
+ * @param display 
+ */
+function clearLayoutProperties(display: WidgetDescription) {
+  delete display.gridLayout;
+  delete display.gridLayoutColumns;
+  delete display.gridCellMargins;
+  delete display.gridCellHeight;
+  delete display.gridCellDragEnabled;
+  delete display.gridCellResizeEnabled;
+
+  delete display.responsiveLayouts;
+  delete display.responsiveBreakpoints;
+  delete display.responsiveColumns;
 }

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -146,7 +146,8 @@ export function useFile(
     fileContents,
     dispatch,
     macros,
-    displayInstance
+    displayInstance,
+    targetDisplayType
   ]);
 
   return [

--- a/src/ui/hooks/useFile.tsx
+++ b/src/ui/hooks/useFile.tsx
@@ -5,7 +5,8 @@ import {
   selectFile,
   fileComparator,
   selectDisplayInstanceByFileAndMacros,
-  createDisplayInstanceFromFile
+  createDisplayInstanceFromFile,
+  convertDisplayInstanceType
 } from "../../redux/slices/fileCacheSlice";
 import { MacroMap } from "../../types/macros";
 import { errorWidget, WidgetDescription } from "../widgets/createComponent";
@@ -77,7 +78,8 @@ export async function fetchAndConvert(
 
 export function useFile(
   file: File,
-  macros?: MacroMap
+  macros?: MacroMap,
+  targetDisplayType?: string
 ): [WidgetDescription, string] {
   const dispatch = useDispatch();
 
@@ -106,6 +108,14 @@ export function useFile(
             macros: macros ?? {}
           })
         );
+        if (targetDisplayType)
+          dispatch(
+            convertDisplayInstanceType({
+              file: file.path,
+              macros: macros ?? {},
+              displayType: targetDisplayType
+            })
+          );
       }
     };
     let isMounted = true;
@@ -116,6 +126,14 @@ export function useFile(
       dispatch(
         createDisplayInstanceFromFile({ file: file.path, macros: macros ?? {} })
       );
+      if (targetDisplayType)
+        dispatch(
+          convertDisplayInstanceType({
+            file: file.path,
+            macros: macros ?? {},
+            displayType: targetDisplayType
+          })
+        );
     }
 
     // Tidy up in case component is unmounted

--- a/src/ui/hooks/useStyle.ts
+++ b/src/ui/hooks/useStyle.ts
@@ -105,7 +105,9 @@ export const useStyle = (
   const themeFont = selectFont(theme, themeName);
 
   const propsBorder = borderToCss(props.border);
-  const hasClassBorder = Boolean(className && themeName in theme?.borders);
+  const hasClassBorder = Boolean(
+    className && theme.borders && themeName in theme?.borders
+  );
   const border = hasClassBorder
     ? themeBorder
     : {
@@ -115,7 +117,9 @@ export const useStyle = (
 
   const visible = props.visible === undefined || props.visible;
 
-  const hasClassColour = Boolean(className && themeName in theme?.palette);
+  const hasClassColour = Boolean(
+    className && theme.palette && themeName in theme?.palette
+  );
   // If palette for class exists, use that
   const colors = hasClassColour
     ? {
@@ -149,7 +153,9 @@ export const useStyle = (
       .filter(x => x[0] != null)
   );
 
-  const hasClassFont = Boolean(className && themeName in theme?.typography);
+  const hasClassFont = Boolean(
+    className && theme.typography && themeName in theme?.typography
+  );
   const font = hasClassFont ? themeFont : fontSelector(theme, props?.font);
 
   const cursor = props.actions?.actions.length ? "pointer" : "auto";

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -9,7 +9,7 @@ import {
   Layout,
   useGridLayout,
   ReactGridLayout,
-  verticalCompactor
+  getCompactor
 } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
@@ -71,6 +71,12 @@ const DisplayGridLayoutProps = {
   gridLayoutColumns: IntPropOpt,
   gridLayout: ObjectArrayPropOpt
 };
+
+const overlapCompactor = getCompactor(
+  null, // use no compactor so elements can float
+  true, // allow overlap
+  false // dont avoid collisions
+)
 
 type DisplayGridLayoutComponentProps = InferWidgetProps<
   typeof DisplayGridLayoutProps
@@ -244,7 +250,7 @@ export const DisplayGridLayoutComponent = (
               cancel: ".no-drag"
             }}
             resizeConfig={{ enabled: gridCellResizeEnabled, handles: ["se"] }}
-            compactor={verticalCompactor}
+            compactor={overlapCompactor}
             onDragStart={(
               layout,
               oldItem,

--- a/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
+++ b/src/ui/widgets/DisplayReactGridLayout/displayGridLayout.tsx
@@ -76,7 +76,7 @@ const overlapCompactor = getCompactor(
   null, // use no compactor so elements can float
   true, // allow overlap
   false // dont avoid collisions
-)
+);
 
 type DisplayGridLayoutComponentProps = InferWidgetProps<
   typeof DisplayGridLayoutProps

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -38,7 +38,8 @@ const DynamicPageProps = {
   border: BorderPropOpt,
   showCloseButton: BoolPropOpt,
   scroll: BoolPropOpt,
-  mjpgEndpoint: StringPropOpt
+  mjpgEndpoint: StringPropOpt,
+  targetDisplayType: StringPropOpt
 };
 
 type DynamicPageComponentProps = InferWidgetProps<typeof DynamicPageProps> &
@@ -148,6 +149,7 @@ export const DynamicPageComponent = (
             x => x != null
           )}
           widgetIdsCallback={props?.widgetIdsCallback}
+          targetDisplayType={newProps.targetDisplayType}
         />
       </ExitFileContext.Provider>
     );

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -56,7 +56,8 @@ const EmbeddedDisplayProps = {
   resize: StringOrNumPropOpt,
   macros: MacrosPropOpt,
   groupName: StringPropOpt,
-  rules: RulesPropOpt
+  rules: RulesPropOpt,
+  targetDisplayType: StringPropOpt
 };
 
 export const EmbeddedDisplay = (
@@ -90,7 +91,8 @@ export const EmbeddedDisplay = (
   const resolvedProps = useRules(macroProps);
   const [description, embeddedDisplayUuid] = useFile(
     resolvedProps.file as File,
-    embeddedDisplayMacroContext.macros
+    embeddedDisplayMacroContext.macros,
+    props.targetDisplayType
   );
 
   const widgetIdsCallback = props?.widgetIdsCallback;


### PR DESCRIPTION
This adds the functionality to convert a loaded file from one type to another. This can mostly be used for loading .bob files as quick screen type displays. If a string containing the type to convert to is passed into a DynamicPage/EmbeddedDisplay, the file contents are modified to add quick screen properties.

Also added tests to support this. Can test using branch convert-quick-screens on Daedalus.