### PR TITLE
Added option for parser to parse rule expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondlightsource/cs-web-lib",
   "type": "module",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {

--- a/src/ui/hooks/useRules.ts
+++ b/src/ui/hooks/useRules.ts
@@ -149,11 +149,12 @@ export function useRules(props: AnyProps): AnyProps {
             log.debug(newProps);
           } else {
             // 'Output expression' - evaluate 'value' and set the prop to the result.
-            const expression = "return " + (exp.convertedValue ?? exp.value._text);
+            const expression =
+              "return " + (exp.convertedValue ?? exp.value._text);
             log.debug(`Output expression ${expression}`);
             // eslint-disable-next-line no-new-func
             const f = Function(...Object.keys(pvVars), expression);
-            
+
             newProps[prop] = f(...Object.values(pvVars));
           }
           log.debug("Props after rule evaluation:");

--- a/src/ui/hooks/useRules.ts
+++ b/src/ui/hooks/useRules.ts
@@ -149,8 +149,7 @@ export function useRules(props: AnyProps): AnyProps {
             log.debug(newProps);
           } else {
             // 'Output expression' - evaluate 'value' and set the prop to the result.
-            const expression =
-              "return " + (exp.convertedValue ?? exp.value);
+            const expression = "return " + (exp.convertedValue ?? exp.value);
             log.debug(`Output expression ${expression}`);
             // eslint-disable-next-line no-new-func
             const f = Function(...Object.keys(pvVars), expression);

--- a/src/ui/hooks/useRules.ts
+++ b/src/ui/hooks/useRules.ts
@@ -150,7 +150,7 @@ export function useRules(props: AnyProps): AnyProps {
           } else {
             // 'Output expression' - evaluate 'value' and set the prop to the result.
             const expression =
-              "return " + (exp.convertedValue ?? exp.value._text);
+              "return " + (exp.convertedValue ?? exp.value);
             log.debug(`Output expression ${expression}`);
             // eslint-disable-next-line no-new-func
             const f = Function(...Object.keys(pvVars), expression);

--- a/src/ui/hooks/useRules.ts
+++ b/src/ui/hooks/useRules.ts
@@ -149,10 +149,11 @@ export function useRules(props: AnyProps): AnyProps {
             log.debug(newProps);
           } else {
             // 'Output expression' - evaluate 'value' and set the prop to the result.
-            const expression = "return " + (exp.convertedValue ?? exp.value);
+            const expression = "return " + (exp.convertedValue ?? exp.value._text);
             log.debug(`Output expression ${expression}`);
             // eslint-disable-next-line no-new-func
             const f = Function(...Object.keys(pvVars), expression);
+            
             newProps[prop] = f(...Object.values(pvVars));
           }
           log.debug("Props after rule evaluation:");

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -295,7 +295,7 @@ export const opiParseRules = (
       const expArray = toArray(ruleElement.exp);
       const expressions = expArray.map(
         (expression: ElementCompact): Expression => {
-          const value = expression.value ?? expression.expression;
+          const value = expression.value ?? expression.expression?._text;
           return {
             boolExp: expression._attributes?.bool_exp as string,
             value: value

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -295,7 +295,7 @@ export const opiParseRules = (
       const expArray = toArray(ruleElement.exp);
       const expressions = expArray.map(
         (expression: ElementCompact): Expression => {
-          const value = expression.value;
+          const value = expression.value ?? expression.expression;
           return {
             boolExp: expression._attributes?.bool_exp as string,
             value: value


### PR DESCRIPTION
The Opacity rule was not working for one of the example images, due to the fact that the bob file xml tag contains expression and not value, and the rules parser was looking for value. 