### PR TITLE
Add and export useDisplayInstance hook

### DIFF
--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -2,3 +2,4 @@ export { useDevice } from "./useDevice";
 export { useConnection } from "./useConnection";
 export { useNotification } from "./useNotification";
 export { refreshFile } from "./useFile";
+export { useDisplayInstance } from "./useDisplayInstance";

--- a/src/ui/hooks/useDisplayInstance.tsx
+++ b/src/ui/hooks/useDisplayInstance.tsx
@@ -1,0 +1,6 @@
+import { useSelector } from "react-redux";
+import { selectDisplayInstance } from "../../redux/slices/fileCacheSlice";
+
+export const useDisplayInstance = (uuid: string) => {
+  return useSelector(state => selectDisplayInstance(state, uuid));
+};


### PR DESCRIPTION
Exports a hook that can be used in Daedalus to get the content of a display instance given the uuid. This hook can be updated in future to add other functionality that Quick Screens might need.