### PR TITLE
Update display instance hook

### DIFF
--- a/src/redux/slices/fileCacheSlice.test.ts
+++ b/src/redux/slices/fileCacheSlice.test.ts
@@ -19,7 +19,8 @@ import fileCacheReducer, {
   convertDisplayInstanceType,
   clearLayoutProperties,
   convertDisplayType,
-  normaliseChildren
+  normaliseChildren,
+  createDisplayInstanceFromQuickScreen
 } from "./fileCacheSlice";
 
 const initialState: FileCacheState = {
@@ -570,6 +571,113 @@ describe("createDisplayInstanceFromFile", () => {
     const result = fileCacheReducer(state, action);
 
     expect(Object.keys(result.displayInstanceCache)).toHaveLength(1);
+  });
+});
+
+describe("createDisplayInstanceFromQuickScreen", () => {
+  it("creates a new display instance", () => {
+    const screenContent = {
+      id: "root",
+      type: "displayResponsive",
+      fileId: "file.bob",
+      embeddedDisplayUuid: "uuid5",
+      position: newAbsolutePosition("0", "0", "0", "0")
+    };
+    const state: FileCacheState = {
+      fileCache: {
+        "new screen": screenContent
+      },
+      displayInstanceCache: {},
+      displayInstanceIndex: {}
+    };
+
+    const action = createDisplayInstanceFromQuickScreen({
+      name: "new screen",
+      content: screenContent,
+      macros: { a: "b" }
+    });
+
+    const result = fileCacheReducer(state, action);
+
+    const instances = Object.values(result.displayInstanceCache);
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0].fileId).toBe("new screen");
+
+    const hash = "new screen::" + JSON.stringify({ a: "b" });
+    expect(result.displayInstanceIndex[hash]).toBeDefined();
+  });
+
+  it("does not create duplicate display instance", () => {
+    const hash = "my screen::" + JSON.stringify({});
+
+    const state: FileCacheState = {
+      fileCache: {
+        "my screen": {
+          id: "root",
+          type: "displayGridLayout",
+          fileId: "file.bob",
+          embeddedDisplayUuid: "uuid1",
+          position: newAbsolutePosition("0", "0", "0", "0")
+        }
+      },
+      displayInstanceCache: {
+        uuid1: {
+          uuid: "uuid1",
+          fileId: "file.bob",
+          macros: {},
+          hash,
+          description: {} as any
+        }
+      },
+      displayInstanceIndex: {
+        [hash]: "uuid1"
+      }
+    };
+
+    const action = createDisplayInstanceFromQuickScreen({
+      name: "my screen",
+      macros: {},
+      content: {
+        id: "root",
+        type: "displayGridLayout",
+        fileId: "file.bob",
+        embeddedDisplayUuid: "uuid1",
+        position: newAbsolutePosition("0", "0", "0", "0")
+      }
+    });
+
+    const result = fileCacheReducer(state, action);
+
+    expect(Object.keys(result.displayInstanceCache)).toHaveLength(1);
+  });
+
+  it("adds to filecache if doesn't exist there already", () => {
+    const hash = "my screen::" + JSON.stringify({});
+
+    const state: FileCacheState = {
+      fileCache: {},
+      displayInstanceCache: {},
+      displayInstanceIndex: {}
+    };
+
+    const action = createDisplayInstanceFromQuickScreen({
+      name: "my screen",
+      macros: {},
+      content: {
+        id: "root",
+        type: "displayGridLayout",
+        fileId: "file.bob",
+        embeddedDisplayUuid: "uuid2",
+        position: newAbsolutePosition("0", "0", "0", "0")
+      }
+    });
+
+    const result = fileCacheReducer(state, action);
+
+    expect(Object.keys(result.displayInstanceCache)).toHaveLength(1);
+    expect(result.displayInstanceIndex[hash]).toBeDefined();
+    expect(result.fileCache["my screen"]).toBeDefined();
   });
 });
 

--- a/src/redux/slices/fileCacheSlice.ts
+++ b/src/redux/slices/fileCacheSlice.ts
@@ -250,6 +250,39 @@ const fileCacheSlice = createSlice({
         state.displayInstanceIndex[hash] = uuid;
       }
     },
+    createDisplayInstanceFromQuickScreen(state, action) {
+      const { name, content, macros } = action.payload;
+      // Add to file cache if it doesn't exist
+      if (!state.fileCache[name]) state.fileCache[name] = content;
+
+      const hash = `${name}::${stringify(macros)}`;
+
+      if (
+        Object.values(state?.displayInstanceCache ?? {}).some(
+          inst => inst.hash === hash
+        )
+      ) {
+        return;
+      }
+
+      const uuid = content.embeddedDisplayUuid;
+
+      if (state.displayInstanceCache) {
+        const parentDir = content.fileId.slice(
+          0,
+          content.fileId.lastIndexOf("/")
+        );
+
+        state.displayInstanceCache[uuid] = {
+          description: resolveWidgetPathsAndMacros(content, parentDir, macros),
+          fileId: name,
+          macros: macros,
+          uuid,
+          hash
+        };
+        state.displayInstanceIndex[hash] = uuid;
+      }
+    },
     convertDisplayInstanceType(state, action) {
       const { uuid, file, macros, displayType } = action.payload;
       let id = uuid;
@@ -283,6 +316,7 @@ export const {
   displayInstanceUpdateGridLayout,
   displayInstanceUpdateResponsiveLayout,
   createDisplayInstanceFromFile,
+  createDisplayInstanceFromQuickScreen,
   convertDisplayInstanceType
 } = fileCacheSlice.actions;
 

--- a/src/ui/hooks/useDisplayInstance.tsx
+++ b/src/ui/hooks/useDisplayInstance.tsx
@@ -1,6 +1,34 @@
-import { useSelector } from "react-redux";
-import { selectDisplayInstance } from "../../redux/slices/fileCacheSlice";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  createDisplayInstanceFromQuickScreen,
+  selectDisplayInstance
+} from "../../redux/slices/fileCacheSlice";
+import { MacroMap } from "../../types/macros";
+import { WidgetDescription } from "../widgets/createComponent";
 
 export const useDisplayInstance = (uuid: string) => {
-  return useSelector(state => selectDisplayInstance(state, uuid));
+  const dispatch = useDispatch();
+
+  const displayInstance = useSelector(state =>
+    selectDisplayInstance(state, uuid)
+  );
+
+  const addDisplayInstanceByDescription = (
+    file: string,
+    macros: MacroMap,
+    description: WidgetDescription
+  ) => {
+    dispatch(
+      createDisplayInstanceFromQuickScreen({
+        name: file,
+        macros,
+        content: description
+      })
+    );
+  };
+
+  return {
+    displayInstance,
+    addDisplayInstanceByDescription
+  };
 };


### PR DESCRIPTION
Updates the display instance hook to add an action that can create a display instance based on file contents, rather than a file path. This can be used when loading Quick Screens in daedalus, as they store file contents in browser local storage.

Can test with PR load-existing-quick-screen on Daedalus.