### PR TITLE
Added script to generate version file from package.json

### DIFF
--- a/.github/workflows/node.install.yml
+++ b/.github/workflows/node.install.yml
@@ -27,5 +27,5 @@ jobs:
       - run: npm audit ----audit-level critical
       - run: npm run all-checks
       - run: npm run test
-      - run: npm run rollup
       - run: npm run generate-version
+      - run: npm run rollup

--- a/.github/workflows/node.install.yml
+++ b/.github/workflows/node.install.yml
@@ -28,3 +28,4 @@ jobs:
       - run: npm run all-checks
       - run: npm run test
       - run: npm run rollup
+      - run: npm run generate-version

--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -34,6 +34,6 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm ci
-      - run: npm run rollup
       - run: npm run generate-version
+      - run: npm run rollup
       - run: npm publish --access public

--- a/.github/workflows/npm-publish-package.yml
+++ b/.github/workflows/npm-publish-package.yml
@@ -35,4 +35,5 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run rollup
+      - run: npm run generate-version
       - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {
-    "prerollup": "node scripts/generate-version.js",
+    "generate-version": "node scripts/generate-version.js",
     "rollup": "rollup -c",
     "test": "vitest",
     "lint": "eslint 'src/**/*.{ts,tsx}' --max-warnings=0",
@@ -13,7 +13,7 @@
     "prettier-check": "prettier --check 'src/**/*.{ts,tsx}'",
     "prettier-write": "prettier --write 'src/**/*.{ts,tsx}'",
     "check-types": "tsc",
-    "all-checks": "npm run lint && npm run prettier-check && npm run check-types"
+    "all-checks": "npm run generate-version && npm run lint && npm run prettier-check && npm run check-types"
   },
   "author": "Will Rogers, Rebecca Williams, Abigail Alexander, Tom Kane, Gregory Harris",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Control system web library",
   "main": "./dist/index.cjs",
   "scripts": {
+    "prerollup": "node scripts/generate-version.js",
     "rollup": "rollup -c",
     "test": "vitest",
     "lint": "eslint 'src/**/*.{ts,tsx}' --max-warnings=0",

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,0 +1,10 @@
+import fs from "fs";
+import path from "path";
+import pkg from "../package.json" with { type: "json" };
+
+const content = `export const CS_WEB_LIB_VERSION = "${pkg.version}";
+`;
+
+fs.writeFileSync(path.resolve("src/version.ts"), content);
+
+console.log(`Generated src/version.ts (${pkg.version})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./ui/widgets";
 export * from "./ui/hooks";
 export * from "./types";
 export { contextRender } from "./testResources";
+export * from "./version";


### PR DESCRIPTION
I tried other methods of versioning and exporting that for Daedalus to use. This method requires having a prerollup script that does the creating of a versioning file, whose variables are then exported.